### PR TITLE
Removed "Object" usage as class name

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Code/Reader/SourceArgumentsReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Code/Reader/SourceArgumentsReaderTest.php
@@ -41,8 +41,8 @@ class SourceArgumentsReaderTest extends \PHPUnit\Framework\TestCase
                     '\Imported\Name\Space\One',
                     '\Imported\Name\Space\AnotherTest\Extended',
                     '\Imported\Name\Space\Test',
-                    '\Imported\Name\Space\Object\Under\Test',
-                    '\Imported\Name\Space\Object',
+                    '\Imported\Name\Space\ClassName\Under\Test',
+                    '\Imported\Name\Space\ClassName',
                     '\Some\Testing\Name\Space\Test',
                     'array',
                     ''

--- a/dev/tests/integration/testsuite/Magento/Framework/Code/Reader/_files/SourceArgumentsReaderTest.php.sample
+++ b/dev/tests/integration/testsuite/Magento/Framework/Code/Reader/_files/SourceArgumentsReaderTest.php.sample
@@ -6,7 +6,7 @@
 namespace Some\Testing\Name\Space;
 
 use Imported\Name\Space\One as FirstImport;
-use Imported\Name\Space\Object;
+use Imported\Name\Space\ClassName;
 use Imported\Name\Space\Test as Testing, \Imported\Name\Space\AnotherTest ;
 
 class AnotherSimpleClass
@@ -16,8 +16,8 @@ class AnotherSimpleClass
         FirstImport $itemTwo,
         AnotherTest\Extended $itemThree,
         Testing $itemFour,
-        Object\Under\Test $itemFive,
-        Object $itemSix,
+        ClassName\Under\Test $itemFive,
+        ClassName $itemSix,
         Test $itemSeven,
         array $itemEight = [],
         $itemNine = 'test'


### PR DESCRIPTION
Removed "Object" usage as class name

### Fixed Issues
1. magento-engcom/php-7.2-support#18: "Object" as class name

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
