### PR TITLE
Fix #20: Removed `each()` function usage

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
@@ -571,8 +571,7 @@ abstract class AbstractResource extends \Magento\Eav\Model\Entity\AbstractEntity
         }
 
         if (is_array($attributesData) && sizeof($attributesData) == 1) {
-            $_data = each($attributesData);
-            $attributesData = $_data[1];
+            $attributesData = array_shift($attributesData);
         }
 
         return $attributesData === false ? false : $attributesData;

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -803,7 +803,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
     {
         $tableAlias = null;
         if (is_array($table)) {
-            list($tableAlias, $tableName) = each($table);
+            list($tableAlias, $tableName) = [key($table), current($table)];
         } else {
             $tableName = $table;
         }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
@@ -124,4 +124,29 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(50, $tierPrices[2]->getExtensionAttributes()->getPercentageValue());
         $this->assertEquals(5, $tierPrices[2]->getValue());
     }
+
+    /**
+     * Checks a case if table for join specified as an array.
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function testJoinTable()
+    {
+        $this->collection->joinTable(
+            ['alias' => 'url_rewrite'],
+            'entity_id = entity_id',
+            ['request_path'],
+            '{{table}}.entity_type = \'product\'',
+            'left'
+        );
+        $sql = (string) $this->collection->getSelect();
+        $productTable = $this->collection->getTable('catalog_product_entity');
+        $urlRewriteTable = $this->collection->getTable('url_rewrite');
+
+        $expected = 'SELECT `e`.*, `alias`.`request_path` FROM `' . $productTable . '` AS `e`'
+            . ' LEFT JOIN `' . $urlRewriteTable . '` AS `alias` ON (alias.entity_id =e.entity_id)'
+            . ' AND (alias.entity_type = \'product\')';
+
+        self::assertContains($expected, str_replace(PHP_EOL, '', $sql));
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/ProductTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Catalog\Model\ResourceModel;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    /**
+     * @var Product
+     */
+    private $model;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+
+        $this->model = $this->objectManager->get(Product::class);
+    }
+
+    /**
+     * Checks a possibility to retrieve product raw attribute value.
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testGetAttributeRawValue()
+    {
+        $sku = 'simple';
+        $attribute = 'name';
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+        $product = $productRepository->get($sku);
+
+        $actual = $this->model->getAttributeRawValue($product->getId(), $attribute, null);
+        self::assertEquals($product->getName(), $actual);
+    }
+}

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/CircularDependencyTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/CircularDependencyTest.php
@@ -44,9 +44,9 @@ class CircularDependencyTest extends \PHPUnit\Framework\TestCase
             $moduleName = str_replace('/', '_', $moduleName[1]);
             $config = simplexml_load_file($configFile);
             $result = $config->xpath("/config/module/depends/module") ?: [];
-            while (list(, $node) = each($result)) {
+            foreach ($result as $node) {
                 /** @var \SimpleXMLElement $node */
-                $this->moduleDependencies[$moduleName][] = (string)$node['name'];
+                $this->moduleDependencies[$moduleName][] = (string) $node['name'];
             }
         }
     }

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ComposerTest.php
@@ -336,7 +336,8 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
             "If there are any component paths specified, then they must be reflected in 'replace' section"
         );
         $flat = $this->getFlatPathsInfo(self::$rootJson['extra']['component_paths']);
-        while (list(, list($component, $path)) = each($flat)) {
+        foreach ($flat as $item) {
+            list($component, $path) = [$item[0], $item[1]];
             $this->assertFileExists(
                 self::$root . '/' . $path,
                 "Missing or invalid component path: {$component} -> {$path}"

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
@@ -2526,5 +2526,6 @@ return [
     ['getDataFormTab', 'Magento\Backend\Test\Block\Widget\Tab', 'Magento\Ui\Test\Block\Adminhtml\AbstractContainer::getFieldsData'],
     ['getBunchImages', 'Magento\CatalogImportExport\Model\Import\Product'],
     ['_isAttributeValueEmpty', 'Magento\Catalog\Model\ResourceModel\AbstractResource'],
-    ['var_dump', '']
+    ['var_dump', ''],
+    ['each', ''],
 ];

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -337,7 +337,8 @@ class Installer
 
         $this->log->log('Starting Magento installation:');
 
-        while (list(, list($message, $method, $params)) = each($script)) {
+        foreach ($script as $item) {
+            list($message, $method, $params) = [$item[0], $item[1], $item[2]];
             $this->log->log($message);
             call_user_func_array([$this, $method], $params);
             $this->logProgress();


### PR DESCRIPTION
Removed `each()` function usage

### Fixed Issues
1. magento-engcom/php-7.2-support#20: Usage of deprecated each() function

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
