### PR TITLE
Update PHP version dependency to ~7.2.0

### DIFF
--- a/app/code/Magento/AdminNotification/composer.json
+++ b/app/code/Magento/AdminNotification/composer.json
@@ -13,6 +13,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/AdvancedPricingImportExport/composer.json
+++ b/app/code/Magento/AdvancedPricingImportExport/composer.json
@@ -15,6 +15,9 @@
         "magento/module-import-export": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Analytics/composer.json
+++ b/app/code/Magento/Analytics/composer.json
@@ -9,6 +9,9 @@
         "magento/module-store": "100.3.*",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Authorization/composer.json
+++ b/app/code/Magento/Authorization/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-backend": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Authorizenet/composer.json
+++ b/app/code/Magento/Authorizenet/composer.json
@@ -15,6 +15,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/Backend/composer.json
+++ b/app/code/Magento/Backend/composer.json
@@ -5,24 +5,27 @@
         "sort-packages": true
     },
     "require": {
-      "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
-      "magento/framework": "100.3.*",
-      "magento/module-backup": "100.3.*",
-      "magento/module-catalog": "101.2.*",
-      "magento/module-config": "100.3.*",
-      "magento/module-customer": "100.3.*",
-      "magento/module-developer": "100.3.*",
-      "magento/module-directory": "100.3.*",
-      "magento/module-eav": "100.3.*",
-      "magento/module-quote": "100.3.*",
-      "magento/module-reports": "100.3.*",
-      "magento/module-require-js": "100.3.*",
-      "magento/module-sales": "100.3.*",
-      "magento/module-security": "100.3.*",
-      "magento/module-store": "100.3.*",
-      "magento/module-translation": "100.3.*",
-      "magento/module-ui": "100.3.*",
-      "magento/module-user": "100.3.*"
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
+        "magento/framework": "100.3.*",
+        "magento/module-backup": "100.3.*",
+        "magento/module-catalog": "101.2.*",
+        "magento/module-config": "100.3.*",
+        "magento/module-customer": "100.3.*",
+        "magento/module-developer": "100.3.*",
+        "magento/module-directory": "100.3.*",
+        "magento/module-eav": "100.3.*",
+        "magento/module-quote": "100.3.*",
+        "magento/module-reports": "100.3.*",
+        "magento/module-require-js": "100.3.*",
+        "magento/module-sales": "100.3.*",
+        "magento/module-security": "100.3.*",
+        "magento/module-store": "100.3.*",
+        "magento/module-translation": "100.3.*",
+        "magento/module-ui": "100.3.*",
+        "magento/module-user": "100.3.*"
+    },
+    "require-dev": {
+        "php": "~7.2.0"
     },
     "suggest": {
         "magento/module-theme": "100.3.*"

--- a/app/code/Magento/Backup/composer.json
+++ b/app/code/Magento/Backup/composer.json
@@ -11,6 +11,9 @@
         "magento/module-cron": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Braintree/composer.json
+++ b/app/code/Magento/Braintree/composer.json
@@ -23,6 +23,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-vault": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-checkout-agreements": "100.3.*",
         "magento/module-theme": "100.3.*"

--- a/app/code/Magento/Bundle/composer.json
+++ b/app/code/Magento/Bundle/composer.json
@@ -23,6 +23,9 @@
         "magento/module-tax": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-webapi": "100.3.*",
         "magento/module-bundle-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/BundleImportExport/composer.json
+++ b/app/code/Magento/BundleImportExport/composer.json
@@ -13,6 +13,9 @@
         "magento/module-eav": "100.3.*",
         "magento/module-import-export": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CacheInvalidate/composer.json
+++ b/app/code/Magento/CacheInvalidate/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-page-cache": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Captcha/composer.json
+++ b/app/code/Magento/Captcha/composer.json
@@ -15,6 +15,9 @@
         "zendframework/zend-db": "^2.8.2",
         "zendframework/zend-session": "^2.7.3"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Catalog/composer.json
+++ b/app/code/Magento/Catalog/composer.json
@@ -31,6 +31,9 @@
         "magento/module-widget": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cookie": "100.3.*",
         "magento/module-sales": "100.3.*",

--- a/app/code/Magento/CatalogAnalytics/composer.json
+++ b/app/code/Magento/CatalogAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-catalog": "101.2.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CatalogImportExport/composer.json
+++ b/app/code/Magento/CatalogImportExport/composer.json
@@ -18,6 +18,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-tax": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CatalogInventory/composer.json
+++ b/app/code/Magento/CatalogInventory/composer.json
@@ -15,6 +15,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CatalogRule/composer.json
+++ b/app/code/Magento/CatalogRule/composer.json
@@ -15,6 +15,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-import-export": "100.3.*",
         "magento/module-catalog-rule-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/CatalogRuleConfigurable/composer.json
+++ b/app/code/Magento/CatalogRuleConfigurable/composer.json
@@ -12,6 +12,9 @@
         "magento/module-catalog-rule": "100.3.*",
         "magento/module-configurable-product": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-catalog-rule": "100.3.*"
     },

--- a/app/code/Magento/CatalogSearch/composer.json
+++ b/app/code/Magento/CatalogSearch/composer.json
@@ -18,6 +18,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CatalogUrlRewrite/composer.json
+++ b/app/code/Magento/CatalogUrlRewrite/composer.json
@@ -16,6 +16,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-url-rewrite": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CatalogWidget/composer.json
+++ b/app/code/Magento/CatalogWidget/composer.json
@@ -16,6 +16,9 @@
         "magento/module-widget": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Checkout/composer.json
+++ b/app/code/Magento/Checkout/composer.json
@@ -26,6 +26,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cookie": "100.3.*"
     },

--- a/app/code/Magento/CheckoutAgreements/composer.json
+++ b/app/code/Magento/CheckoutAgreements/composer.json
@@ -12,6 +12,9 @@
         "magento/module-quote": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Cms/composer.json
+++ b/app/code/Magento/Cms/composer.json
@@ -17,6 +17,9 @@
         "magento/module-variable": "100.3.*",
         "magento/module-widget": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cms-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/CmsUrlRewrite/composer.json
+++ b/app/code/Magento/CmsUrlRewrite/composer.json
@@ -11,6 +11,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-url-rewrite": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Config/composer.json
+++ b/app/code/Magento/Config/composer.json
@@ -15,6 +15,9 @@
         "magento/module-media-storage": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/ConfigurableImportExport/composer.json
+++ b/app/code/Magento/ConfigurableImportExport/composer.json
@@ -13,6 +13,9 @@
         "magento/module-eav": "100.3.*",
         "magento/module-import-export": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/ConfigurableProduct/composer.json
+++ b/app/code/Magento/ConfigurableProduct/composer.json
@@ -19,6 +19,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-webapi": "100.3.*",
         "magento/module-sales": "100.3.*",

--- a/app/code/Magento/ConfigurableProductSales/composer.json
+++ b/app/code/Magento/ConfigurableProductSales/composer.json
@@ -11,6 +11,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-configurable-product": "100.3.*"
     },

--- a/app/code/Magento/Contact/composer.json
+++ b/app/code/Magento/Contact/composer.json
@@ -12,6 +12,9 @@
         "magento/module-customer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Cookie/composer.json
+++ b/app/code/Magento/Cookie/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-backend": "100.3.*"
     },

--- a/app/code/Magento/Cron/composer.json
+++ b/app/code/Magento/Cron/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/CurrencySymbol/composer.json
+++ b/app/code/Magento/CurrencySymbol/composer.json
@@ -13,6 +13,9 @@
         "magento/module-page-cache": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Customer/composer.json
+++ b/app/code/Magento/Customer/composer.json
@@ -27,6 +27,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cookie": "100.3.*",
         "magento/module-customer-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/CustomerAnalytics/composer.json
+++ b/app/code/Magento/CustomerAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-customer": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/CustomerImportExport/composer.json
+++ b/app/code/Magento/CustomerImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/module-import-export": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Deploy/composer.json
+++ b/app/code/Magento/Deploy/composer.json
@@ -12,6 +12,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-user": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Developer/composer.json
+++ b/app/code/Magento/Developer/composer.json
@@ -10,6 +10,9 @@
         "magento/module-config": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Dhl/composer.json
+++ b/app/code/Magento/Dhl/composer.json
@@ -18,6 +18,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-checkout": "100.3.*"
     },

--- a/app/code/Magento/Directory/composer.json
+++ b/app/code/Magento/Directory/composer.json
@@ -12,6 +12,9 @@
         "magento/module-config": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Downloadable/composer.json
+++ b/app/code/Magento/Downloadable/composer.json
@@ -24,6 +24,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-downloadable-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/DownloadableImportExport/composer.json
+++ b/app/code/Magento/DownloadableImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/module-import-export": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Eav/composer.json
+++ b/app/code/Magento/Eav/composer.json
@@ -13,6 +13,9 @@
         "magento/module-media-storage": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Email/composer.json
+++ b/app/code/Magento/Email/composer.json
@@ -14,6 +14,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-variable": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-theme": "100.3.*"
     },

--- a/app/code/Magento/EncryptionKey/composer.json
+++ b/app/code/Magento/EncryptionKey/composer.json
@@ -10,6 +10,9 @@
         "magento/module-backend": "100.3.*",
         "magento/module-config": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Fedex/composer.json
+++ b/app/code/Magento/Fedex/composer.json
@@ -17,6 +17,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/GiftMessage/composer.json
+++ b/app/code/Magento/GiftMessage/composer.json
@@ -16,6 +16,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-multishipping": "100.3.*"
     },

--- a/app/code/Magento/GoogleAdwords/composer.json
+++ b/app/code/Magento/GoogleAdwords/composer.json
@@ -10,6 +10,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/GoogleAnalytics/composer.json
+++ b/app/code/Magento/GoogleAnalytics/composer.json
@@ -11,6 +11,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/GoogleOptimizer/composer.json
+++ b/app/code/Magento/GoogleOptimizer/composer.json
@@ -14,6 +14,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/GraphQl/composer.json
+++ b/app/code/Magento/GraphQl/composer.json
@@ -11,6 +11,9 @@
         "magento/module-eav": "100.3.*",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/app/code/Magento/GraphQlCatalog/composer.json
+++ b/app/code/Magento/GraphQlCatalog/composer.json
@@ -13,6 +13,9 @@
         "magento/module-store": "100.3.*",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/app/code/Magento/GraphQlConfigurableProduct/composer.json
+++ b/app/code/Magento/GraphQlConfigurableProduct/composer.json
@@ -11,6 +11,9 @@
         "magento/module-graph-ql-catalog": "100.0.*",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/app/code/Magento/GraphQlCustomer/composer.json
+++ b/app/code/Magento/GraphQlCustomer/composer.json
@@ -10,6 +10,9 @@
     "magento/module-graph-ql-eav": "100.0.*",
     "magento/framework": "100.3.*"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/app/code/Magento/GraphQlEav/composer.json
+++ b/app/code/Magento/GraphQlEav/composer.json
@@ -8,6 +8,9 @@
         "magento/module-graph-ql": "100.0.*",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/app/code/Magento/GroupedImportExport/composer.json
+++ b/app/code/Magento/GroupedImportExport/composer.json
@@ -13,6 +13,9 @@
         "magento/module-grouped-product": "100.3.*",
         "magento/module-import-export": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/GroupedProduct/composer.json
+++ b/app/code/Magento/GroupedProduct/composer.json
@@ -20,6 +20,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-grouped-product-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/ImportExport/composer.json
+++ b/app/code/Magento/ImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/module-media-storage": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Indexer/composer.json
+++ b/app/code/Magento/Indexer/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-backend": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/InstantPurchase/composer.json
+++ b/app/code/Magento/InstantPurchase/composer.json
@@ -17,6 +17,9 @@
     "magento/module-vault": "100.3.*",
     "magento/framework": "100.3.*"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "autoload": {
     "files": [
       "registration.php"

--- a/app/code/Magento/Integration/composer.json
+++ b/app/code/Magento/Integration/composer.json
@@ -14,6 +14,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-user": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Marketplace/composer.json
+++ b/app/code/Magento/Marketplace/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-backend": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/MediaStorage/composer.json
+++ b/app/code/Magento/MediaStorage/composer.json
@@ -11,6 +11,9 @@
         "magento/module-config": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Msrp/composer.json
+++ b/app/code/Magento/Msrp/composer.json
@@ -14,6 +14,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-tax": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-bundle": "100.3.*",
         "magento/module-msrp-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/Multishipping/composer.json
+++ b/app/code/Magento/Multishipping/composer.json
@@ -16,6 +16,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-tax": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-theme": "100.3.*"
     },

--- a/app/code/Magento/NewRelicReporting/composer.json
+++ b/app/code/Magento/NewRelicReporting/composer.json
@@ -15,6 +15,9 @@
         "magento/module-customer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Newsletter/composer.json
+++ b/app/code/Magento/Newsletter/composer.json
@@ -16,6 +16,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-widget": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/OfflinePayments/composer.json
+++ b/app/code/Magento/OfflinePayments/composer.json
@@ -10,6 +10,9 @@
         "magento/module-checkout": "100.3.*",
         "magento/module-payment": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/OfflineShipping/composer.json
+++ b/app/code/Magento/OfflineShipping/composer.json
@@ -17,6 +17,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-checkout": "100.3.*",
         "magento/module-offline-shipping-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/PageCache/composer.json
+++ b/app/code/Magento/PageCache/composer.json
@@ -11,6 +11,9 @@
         "magento/module-config": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Payment/composer.json
+++ b/app/code/Magento/Payment/composer.json
@@ -14,6 +14,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Paypal/composer.json
+++ b/app/code/Magento/Paypal/composer.json
@@ -25,6 +25,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-vault": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-checkout-agreements": "100.3.*"
     },

--- a/app/code/Magento/Persistent/composer.json
+++ b/app/code/Magento/Persistent/composer.json
@@ -14,6 +14,9 @@
         "magento/module-quote": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/ProductAlert/composer.json
+++ b/app/code/Magento/ProductAlert/composer.json
@@ -12,6 +12,9 @@
         "magento/module-customer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/ProductVideo/composer.json
+++ b/app/code/Magento/ProductVideo/composer.json
@@ -14,6 +14,9 @@
         "magento/module-media-storage": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-customer": "100.3.*",
         "magento/module-config": "100.3.*"

--- a/app/code/Magento/Quote/composer.json
+++ b/app/code/Magento/Quote/composer.json
@@ -22,6 +22,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-tax": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-webapi": "100.3.*"
     },

--- a/app/code/Magento/QuoteAnalytics/composer.json
+++ b/app/code/Magento/QuoteAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-quote": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/ReleaseNotification/composer.json
+++ b/app/code/Magento/ReleaseNotification/composer.json
@@ -8,6 +8,9 @@
     "magento/module-ui": "100.3.*",
     "magento/framework": "101.0.*"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "suggest": {
     "magento/module-config": "100.3.*"
   },

--- a/app/code/Magento/Reports/composer.json
+++ b/app/code/Magento/Reports/composer.json
@@ -24,6 +24,9 @@
         "magento/module-widget": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/RequireJs/composer.json
+++ b/app/code/Magento/RequireJs/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Review/composer.json
+++ b/app/code/Magento/Review/composer.json
@@ -16,6 +16,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cookie": "100.3.*",
         "magento/module-review-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/ReviewAnalytics/composer.json
+++ b/app/code/Magento/ReviewAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-review": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Robots/composer.json
+++ b/app/code/Magento/Robots/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-theme": "100.3.*"
     },

--- a/app/code/Magento/Rss/composer.json
+++ b/app/code/Magento/Rss/composer.json
@@ -11,6 +11,9 @@
         "magento/module-customer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Rule/composer.json
+++ b/app/code/Magento/Rule/composer.json
@@ -13,6 +13,9 @@
         "magento/module-eav": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Sales/composer.json
+++ b/app/code/Magento/Sales/composer.json
@@ -31,6 +31,9 @@
         "magento/module-widget": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-sales-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/SalesAnalytics/composer.json
+++ b/app/code/Magento/SalesAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-sales": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/SalesInventory/composer.json
+++ b/app/code/Magento/SalesInventory/composer.json
@@ -12,6 +12,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/SalesRule/composer.json
+++ b/app/code/Magento/SalesRule/composer.json
@@ -24,6 +24,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-widget": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-sales-rule-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/SalesSequence/composer.json
+++ b/app/code/Magento/SalesSequence/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/SampleData/composer.json
+++ b/app/code/Magento/SampleData/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/sample-data-media": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/Search/composer.json
+++ b/app/code/Magento/Search/composer.json
@@ -13,6 +13,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Security/composer.json
+++ b/app/code/Magento/Security/composer.json
@@ -10,6 +10,9 @@
         "magento/module-backend": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-customer": "100.3.*"
     },

--- a/app/code/Magento/SendFriend/composer.json
+++ b/app/code/Magento/SendFriend/composer.json
@@ -11,6 +11,9 @@
         "magento/module-customer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Shipping/composer.json
+++ b/app/code/Magento/Shipping/composer.json
@@ -22,6 +22,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-user": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-fedex": "100.3.*",
         "magento/module-ups": "100.3.*",

--- a/app/code/Magento/Sitemap/composer.json
+++ b/app/code/Magento/Sitemap/composer.json
@@ -17,6 +17,9 @@
         "magento/module-robots": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/Store/composer.json
+++ b/app/code/Magento/Store/composer.json
@@ -13,6 +13,9 @@
         "magento/module-media-storage": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-deploy": "100.3.*"
     },

--- a/app/code/Magento/Swagger/composer.json
+++ b/app/code/Magento/Swagger/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Swatches/composer.json
+++ b/app/code/Magento/Swatches/composer.json
@@ -17,6 +17,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-theme": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-layered-navigation": "100.3.*",
         "magento/module-swatches-sample-data": "Sample Data version:100.3.*"

--- a/app/code/Magento/SwatchesLayeredNavigation/composer.json
+++ b/app/code/Magento/SwatchesLayeredNavigation/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/magento-composer-installer": "*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Tax/composer.json
+++ b/app/code/Magento/Tax/composer.json
@@ -21,6 +21,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-tax-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/TaxImportExport/composer.json
+++ b/app/code/Magento/TaxImportExport/composer.json
@@ -12,6 +12,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-tax": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Theme/composer.json
+++ b/app/code/Magento/Theme/composer.json
@@ -18,6 +18,9 @@
         "magento/module-ui": "100.3.*",
         "magento/module-widget": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-translation": "100.3.*",
         "magento/module-theme-sample-data": "Sample Data version:100.3.*",

--- a/app/code/Magento/Tinymce3/composer.json
+++ b/app/code/Magento/Tinymce3/composer.json
@@ -8,6 +8,9 @@
         "magento/module-variable": "100.3.*",
         "magento/module-widget": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-cms": "100.3.*"
     },

--- a/app/code/Magento/Translation/composer.json
+++ b/app/code/Magento/Translation/composer.json
@@ -11,6 +11,9 @@
         "magento/module-developer": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-deploy": "100.3.*"
     },

--- a/app/code/Magento/Ui/composer.json
+++ b/app/code/Magento/Ui/composer.json
@@ -12,6 +12,9 @@
         "magento/module-eav": "100.3.*",
         "magento/module-user": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/Ups/composer.json
+++ b/app/code/Magento/Ups/composer.json
@@ -15,6 +15,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-config": "100.3.*"
     },

--- a/app/code/Magento/UrlRewrite/composer.json
+++ b/app/code/Magento/UrlRewrite/composer.json
@@ -14,6 +14,9 @@
         "magento/module-cms-url-rewrite": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/User/composer.json
+++ b/app/code/Magento/User/composer.json
@@ -14,6 +14,9 @@
         "magento/module-security": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Usps/composer.json
+++ b/app/code/Magento/Usps/composer.json
@@ -17,6 +17,9 @@
         "magento/module-shipping": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Variable/composer.json
+++ b/app/code/Magento/Variable/composer.json
@@ -11,6 +11,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-config": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Vault/composer.json
+++ b/app/code/Magento/Vault/composer.json
@@ -14,6 +14,9 @@
         "magento/module-sales": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Version/composer.json
+++ b/app/code/Magento/Version/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Webapi/composer.json
+++ b/app/code/Magento/Webapi/composer.json
@@ -12,6 +12,9 @@
         "magento/module-integration": "100.3.*",
         "magento/module-store": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-user": "100.3.*",
         "magento/module-customer": "100.3.*"

--- a/app/code/Magento/WebapiSecurity/composer.json
+++ b/app/code/Magento/WebapiSecurity/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/module-webapi": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/code/Magento/Weee/composer.json
+++ b/app/code/Magento/Weee/composer.json
@@ -20,6 +20,9 @@
         "magento/module-tax": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-bundle": "100.3.*"
     },

--- a/app/code/Magento/Widget/composer.json
+++ b/app/code/Magento/Widget/composer.json
@@ -14,6 +14,9 @@
         "magento/module-theme": "100.3.*",
         "magento/module-variable": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-widget-sample-data": "Sample Data version:100.3.*"
     },

--- a/app/code/Magento/Wishlist/composer.json
+++ b/app/code/Magento/Wishlist/composer.json
@@ -17,6 +17,9 @@
         "magento/module-store": "100.3.*",
         "magento/module-ui": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/module-configurable-product": "100.3.*",
         "magento/module-downloadable": "100.3.*",

--- a/app/code/Magento/WishlistAnalytics/composer.json
+++ b/app/code/Magento/WishlistAnalytics/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "100.3.*",
         "magento/module-wishlist": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-module",
     "version": "100.3.0-dev",
     "license": [

--- a/app/design/adminhtml/Magento/backend/composer.json
+++ b/app/design/adminhtml/Magento/backend/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "100.3.0-dev",
     "license": [

--- a/app/design/frontend/Magento/blank/composer.json
+++ b/app/design/frontend/Magento/blank/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "100.3.0-dev",
     "license": [

--- a/app/design/frontend/Magento/luma/composer.json
+++ b/app/design/frontend/Magento/luma/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "100.3.*",
         "magento/theme-frontend-blank": "100.3.*"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "100.3.0-dev",
     "license": [

--- a/app/design/frontend/Magento/rush/composer.json
+++ b/app/design/frontend/Magento/rush/composer.json
@@ -5,6 +5,9 @@
     "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
     "magento/framework": "100.3.*"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "type": "magento2-theme",
   "version": "100.3.0-dev",
   "license": ["OSL-3.0", "AFL-3.0"],

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "webonyx/graphql-php": "^0.11.1"
     },
     "require-dev": {
+        "php": "~7.2.0",
         "friendsofphp/php-cs-fixer": "~2.1.1",
         "lusitanian/oauth": "~0.8.10",
         "pdepend/pdepend": "2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "17cb7438ef1ede96decc0ba375c2b7b1",
-    "content-hash": "99b8883924a448591e08d02aac62b7a5",
+    "content-hash": "0f878b7f57e57097ca0aee3f3a1b41b3",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -52,7 +51,7 @@
                 }
             ],
             "description": "Braintree PHP Client Library",
-            "time": "2017-02-16 19:59:04"
+            "time": "2017-02-16T19:59:04+00:00"
         },
         {
             "name": "colinmollenhour/cache-backend-file",
@@ -88,7 +87,7 @@
             ],
             "description": "The stock Zend_Cache_Backend_File backend has extremely poor performance for cleaning by tags making it become unusable as the number of cached items increases. This backend makes many changes resulting in a huge performance boost, especially for tag cleaning.",
             "homepage": "https://github.com/colinmollenhour/Cm_Cache_Backend_File",
-            "time": "2016-05-02 16:24:47"
+            "time": "2016-05-02T16:24:47+00:00"
         },
         {
             "name": "colinmollenhour/cache-backend-redis",
@@ -124,7 +123,7 @@
             ],
             "description": "Zend_Cache backend using Redis with full support for tags.",
             "homepage": "https://github.com/colinmollenhour/Cm_Cache_Backend_Redis",
-            "time": "2017-03-25 04:54:24"
+            "time": "2017-03-25T04:54:24+00:00"
         },
         {
             "name": "colinmollenhour/credis",
@@ -163,7 +162,7 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2015-11-28 01:20:04"
+            "time": "2015-11-28T01:20:04+00:00"
         },
         {
             "name": "colinmollenhour/php-redis-session-abstract",
@@ -200,7 +199,7 @@
             ],
             "description": "A Redis-based session handler with optimistic locking",
             "homepage": "https://github.com/colinmollenhour/php-redis-session-abstract",
-            "time": "2017-04-19 14:21:43"
+            "time": "2017-04-19T14:21:43+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -256,7 +255,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-11-29 09:37:33"
+            "time": "2017-11-29T09:37:33+00:00"
         },
         {
             "name": "composer/composer",
@@ -333,7 +332,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2017-03-10 08:29:45"
+            "time": "2017-03-10T08:29:45+00:00"
         },
         {
             "name": "composer/semver",
@@ -395,27 +394,27 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30 16:08:34"
+            "time": "2016-08-30T16:08:34+00:00"
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.1.6",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c"
+                "reference": "2d899e9b33023c631854f36c39ef9f8317a7ab33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
-                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2d899e9b33023c631854f36c39ef9f8317a7ab33",
+                "reference": "2d899e9b33023c631854f36c39ef9f8317a7ab33",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
                 "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
             },
             "type": "library",
@@ -456,7 +455,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2017-04-03 19:08:52"
+            "time": "2018-01-03T16:37:06+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -487,7 +486,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -553,7 +552,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-10-21 13:15:38"
+            "time": "2017-10-21T13:15:38+00:00"
         },
         {
             "name": "league/climate",
@@ -602,7 +601,7 @@
                 "php",
                 "terminal"
             ],
-            "time": "2015-01-18 14:31:58"
+            "time": "2015-01-18T14:31:58+00:00"
         },
         {
             "name": "magento/composer",
@@ -638,20 +637,20 @@
                 "AFL-3.0"
             ],
             "description": "Magento composer library helps to instantiate Composer application and run composer commands.",
-            "time": "2017-04-24 09:57:02"
+            "time": "2017-04-24T09:57:02+00:00"
         },
         {
             "name": "magento/magento-composer-installer",
-            "version": "0.1.12",
+            "version": "0.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-composer-installer.git",
-                "reference": "10c600e88ad34fec71bb6b435ea8415ce92d51de"
+                "reference": "8b6c32f53b4944a5d6656e86344cd0f9784709a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-composer-installer/zipball/10c600e88ad34fec71bb6b435ea8415ce92d51de",
-                "reference": "10c600e88ad34fec71bb6b435ea8415ce92d51de",
+                "url": "https://api.github.com/repos/magento/magento-composer-installer/zipball/8b6c32f53b4944a5d6656e86344cd0f9784709a1",
+                "reference": "8b6c32f53b4944a5d6656e86344cd0f9784709a1",
                 "shasum": ""
             },
             "require": {
@@ -717,7 +716,7 @@
                 "composer-installer",
                 "magento"
             ],
-            "time": "2016-10-06 16:05:07"
+            "time": "2017-12-29T16:45:24+00:00"
         },
         {
             "name": "magento/zendframework1",
@@ -764,7 +763,7 @@
                 "ZF1",
                 "framework"
             ],
-            "time": "2017-06-21 14:56:23"
+            "time": "2017-06-21T14:56:23+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -842,7 +841,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19 01:22:40"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "oyejorge/less.php",
@@ -904,7 +903,7 @@
                 "php",
                 "stylesheet"
             ],
-            "time": "2017-03-28 22:19:25"
+            "time": "2017-03-28T22:19:25+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -952,19 +951,19 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-09-27 21:40:39"
+            "time": "2017-09-27T21:40:39+00:00"
         },
         {
             "name": "pelago/emogrifier",
             "version": "V1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jjriv/emogrifier.git",
+                "url": "https://github.com/MyIntervals/emogrifier.git",
                 "reference": "a1db453bb504597d821efcc04b21c79a6021e00c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jjriv/emogrifier/zipball/a1db453bb504597d821efcc04b21c79a6021e00c",
+                "url": "https://api.github.com/repos/MyIntervals/emogrifier/zipball/a1db453bb504597d821efcc04b21c79a6021e00c",
                 "reference": "a1db453bb504597d821efcc04b21c79a6021e00c",
                 "shasum": ""
             },
@@ -1012,7 +1011,7 @@
             ],
             "description": "Converts CSS styles into inline style attributes in your HTML code",
             "homepage": "http://www.pelagodesign.com/sidecar/emogrifier/",
-            "time": "2017-03-02 12:51:48"
+            "time": "2017-03-02T12:51:48+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -1104,7 +1103,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2017-11-29 06:38:08"
+            "time": "2017-11-29T06:38:08+00:00"
         },
         {
             "name": "psr/container",
@@ -1153,7 +1152,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -1200,7 +1199,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1282,7 +1281,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2017-03-26 20:37:53"
+            "time": "2017-03-26T20:37:53+00:00"
         },
         {
             "name": "seld/cli-prompt",
@@ -1330,27 +1329,27 @@
                 "input",
                 "prompt"
             ],
-            "time": "2017-03-18 11:32:45"
+            "time": "2017-03-18T11:32:45+00:00"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.6.2",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19"
+                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
-                "reference": "7a30649c67ee0d19faacfd9fa2cfb6cc032d9b19",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9b355654ea99460397b89c132b5c1087b6bf4473",
+                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "bin": [
                 "bin/jsonlint"
@@ -1379,7 +1378,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-11-30 15:34:22"
+            "time": "2018-01-03T12:13:57+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1423,7 +1422,7 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13 18:44:15"
+            "time": "2015-10-13T18:44:15+00:00"
         },
         {
             "name": "sjparkinson/static-review",
@@ -1477,20 +1476,20 @@
             ],
             "description": "An extendable framework for version control hooks.",
             "abandoned": "phpro/grumphp",
-            "time": "2014-09-22 08:40:36"
+            "time": "2014-09-22T08:40:36+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.32",
+            "version": "v2.8.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "46270f1ca44f08ebc134ce120fd2c2baf5fd63de"
+                "reference": "a4bd0f02ea156cf7b5138774a7ba0ab44d8da4fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/46270f1ca44f08ebc134ce120fd2c2baf5fd63de",
-                "reference": "46270f1ca44f08ebc134ce120fd2c2baf5fd63de",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a4bd0f02ea156cf7b5138774a7ba0ab44d8da4fe",
+                "reference": "a4bd0f02ea156cf7b5138774a7ba0ab44d8da4fe",
                 "shasum": ""
             },
             "require": {
@@ -1538,7 +1537,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-29 09:33:18"
+            "time": "2018-01-03T07:36:31+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1595,20 +1594,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 07:22:48"
+            "time": "2016-07-30T07:22:48+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.32",
+            "version": "v2.8.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b59aacf238fadda50d612c9de73b74751872a903"
+                "reference": "d64be24fc1eba62f9daace8a8918f797fc8e87cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b59aacf238fadda50d612c9de73b74751872a903",
-                "reference": "b59aacf238fadda50d612c9de73b74751872a903",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d64be24fc1eba62f9daace8a8918f797fc8e87cc",
+                "reference": "d64be24fc1eba62f9daace8a8918f797fc8e87cc",
                 "shasum": ""
             },
             "require": {
@@ -1655,20 +1654,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05 15:25:56"
+            "time": "2018-01-03T07:36:31+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.2",
+            "version": "v3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "25b135bea251829e3db6a77d773643408b575ed4"
+                "reference": "e078773ad6354af38169faf31c21df0f18ace03d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/25b135bea251829e3db6a77d773643408b575ed4",
-                "reference": "25b135bea251829e3db6a77d773643408b575ed4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e078773ad6354af38169faf31c21df0f18ace03d",
+                "reference": "e078773ad6354af38169faf31c21df0f18ace03d",
                 "shasum": ""
             },
             "require": {
@@ -1704,20 +1703,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.2",
+            "version": "v3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a"
+                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/dac8d7db537bac7ad8143eb11360a8c2231f251a",
-                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/613e26310776f49a1773b6737c6bd554b8bc8c6f",
+                "reference": "613e26310776f49a1773b6737c6bd554b8bc8c6f",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1752,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05 16:10:10"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1812,20 +1811,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.32",
+            "version": "v2.8.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d25449e031f600807949aab7cadbf267712f4eee"
+                "reference": "ea3226daa3c6789efa39570bfc6e5d55f7561a0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d25449e031f600807949aab7cadbf267712f4eee",
-                "reference": "d25449e031f600807949aab7cadbf267712f4eee",
+                "url": "https://api.github.com/repos/symfony/process/zipball/ea3226daa3c6789efa39570bfc6e5d55f7561a0a",
+                "reference": "ea3226daa3c6789efa39570bfc6e5d55f7561a0a",
                 "shasum": ""
             },
             "require": {
@@ -1861,7 +1860,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05 15:25:56"
+            "time": "2018-01-03T07:36:31+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -1907,7 +1906,7 @@
                 "javascript",
                 "minifier"
             ],
-            "time": "2015-07-04 07:35:09"
+            "time": "2015-07-04T07:35:09+00:00"
         },
         {
             "name": "tubalmartin/cssmin",
@@ -1960,7 +1959,7 @@
                 "minify",
                 "yui"
             ],
-            "time": "2017-05-16 13:45:26"
+            "time": "2017-05-16T13:45:26+00:00"
         },
         {
             "name": "webonyx/graphql-php",
@@ -2007,7 +2006,7 @@
                 "api",
                 "graphql"
             ],
-            "time": "2017-12-12 09:03:21"
+            "time": "2017-12-12T09:03:21+00:00"
         },
         {
             "name": "zendframework/zend-captcha",
@@ -2064,31 +2063,31 @@
                 "captcha",
                 "zf2"
             ],
-            "time": "2017-02-23 08:09:44"
+            "time": "2017-02-23T08:09:44+00:00"
         },
         {
             "name": "zendframework/zend-code",
-            "version": "3.1.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27"
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2899c17f83a7207f2d7f53ec2f421204d3beea27",
-                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^7.1",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^4.8.21",
-                "squizlabs/php_codesniffer": "^2.5",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -2098,8 +2097,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -2117,7 +2116,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24 13:23:32"
+            "time": "2017-10-20T15:21:32+00:00"
         },
         {
             "name": "zendframework/zend-config",
@@ -2173,7 +2172,7 @@
                 "config",
                 "zf2"
             ],
-            "time": "2016-02-04 23:01:10"
+            "time": "2016-02-04T23:01:10+00:00"
         },
         {
             "name": "zendframework/zend-console",
@@ -2225,7 +2224,7 @@
                 "console",
                 "zf2"
             ],
-            "time": "2016-02-09 17:15:12"
+            "time": "2016-02-09T17:15:12+00:00"
         },
         {
             "name": "zendframework/zend-crypt",
@@ -2275,7 +2274,7 @@
                 "crypt",
                 "zf2"
             ],
-            "time": "2016-02-03 23:46:30"
+            "time": "2016-02-03T23:46:30+00:00"
         },
         {
             "name": "zendframework/zend-db",
@@ -2333,7 +2332,7 @@
                 "db",
                 "zf"
             ],
-            "time": "2017-12-11 14:57:52"
+            "time": "2017-12-11T14:57:52+00:00"
         },
         {
             "name": "zendframework/zend-di",
@@ -2380,7 +2379,7 @@
                 "di",
                 "zf2"
             ],
-            "time": "2016-04-25 20:58:11"
+            "time": "2016-04-25T20:58:11+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -2424,7 +2423,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30 19:48:38"
+            "time": "2016-06-30T19:48:38+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -2471,7 +2470,7 @@
                 "eventmanager",
                 "zf2"
             ],
-            "time": "2017-12-12 17:48:56"
+            "time": "2017-12-12T17:48:56+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -2531,7 +2530,7 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2017-05-17 20:56:17"
+            "time": "2017-05-17T20:56:17+00:00"
         },
         {
             "name": "zendframework/zend-form",
@@ -2609,7 +2608,7 @@
                 "form",
                 "zf"
             ],
-            "time": "2017-12-06 21:09:08"
+            "time": "2017-12-06T21:09:08+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2662,7 +2661,7 @@
                 "zend",
                 "zf"
             ],
-            "time": "2017-10-13 12:06:24"
+            "time": "2017-10-13T12:06:24+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -2720,7 +2719,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-02-18 22:38:26"
+            "time": "2016-02-18T22:38:26+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -2787,7 +2786,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2017-05-17 17:00:12"
+            "time": "2017-05-17T17:00:12+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
@@ -2843,7 +2842,7 @@
                 "inputfilter",
                 "zf"
             ],
-            "time": "2017-12-04 21:24:25"
+            "time": "2017-12-04T21:24:25+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -2898,7 +2897,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-02-04T21:20:26+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -2942,7 +2941,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-log",
@@ -3013,7 +3012,7 @@
                 "logging",
                 "zf2"
             ],
-            "time": "2017-05-17 16:03:26"
+            "time": "2017-05-17T16:03:26+00:00"
         },
         {
             "name": "zendframework/zend-mail",
@@ -3075,7 +3074,7 @@
                 "mail",
                 "zf2"
             ],
-            "time": "2017-06-08 20:03:58"
+            "time": "2017-06-08T20:03:58+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -3125,7 +3124,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2016-04-07 16:29:53"
+            "time": "2016-04-07T16:29:53+00:00"
         },
         {
             "name": "zendframework/zend-mime",
@@ -3176,7 +3175,7 @@
                 "mime",
                 "zf"
             ],
-            "time": "2017-11-28 15:02:22"
+            "time": "2017-11-28T15:02:22+00:00"
         },
         {
             "name": "zendframework/zend-modulemanager",
@@ -3236,7 +3235,7 @@
                 "modulemanager",
                 "zf"
             ],
-            "time": "2017-12-02 06:11:18"
+            "time": "2017-12-02T06:11:18+00:00"
         },
         {
             "name": "zendframework/zend-mvc",
@@ -3323,7 +3322,7 @@
                 "mvc",
                 "zf2"
             ],
-            "time": "2016-02-23 15:24:59"
+            "time": "2016-02-23T15:24:59+00:00"
         },
         {
             "name": "zendframework/zend-serializer",
@@ -3381,7 +3380,7 @@
                 "serializer",
                 "zf2"
             ],
-            "time": "2017-11-20 22:21:04"
+            "time": "2017-11-20T22:21:04+00:00"
         },
         {
             "name": "zendframework/zend-server",
@@ -3427,7 +3426,7 @@
                 "server",
                 "zf2"
             ],
-            "time": "2016-06-20 22:27:55"
+            "time": "2016-06-20T22:27:55+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -3479,7 +3478,7 @@
                 "servicemanager",
                 "zf2"
             ],
-            "time": "2017-12-05 16:27:36"
+            "time": "2017-12-05T16:27:36+00:00"
         },
         {
             "name": "zendframework/zend-session",
@@ -3549,7 +3548,7 @@
                 "session",
                 "zf"
             ],
-            "time": "2017-12-01 17:35:04"
+            "time": "2017-12-01T17:35:04+00:00"
         },
         {
             "name": "zendframework/zend-soap",
@@ -3601,7 +3600,7 @@
                 "soap",
                 "zf2"
             ],
-            "time": "2016-04-21 16:06:27"
+            "time": "2016-04-21T16:06:27+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -3660,7 +3659,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:17:31"
+            "time": "2016-04-12T21:17:31+00:00"
         },
         {
             "name": "zendframework/zend-text",
@@ -3707,7 +3706,7 @@
                 "text",
                 "zf2"
             ],
-            "time": "2016-02-08 19:03:52"
+            "time": "2016-02-08T19:03:52+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -3754,7 +3753,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -3825,20 +3824,20 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-08-22 14:19:23"
+            "time": "2017-08-22T14:19:23+00:00"
         },
         {
             "name": "zendframework/zend-view",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-view.git",
-                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3"
+                "reference": "4478cc5dd960e2339d88b363ef99fa278700e80e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/3b6342c381c4437a03fc81d0064c0bb8924914d3",
-                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3",
+                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/4478cc5dd960e2339d88b363ef99fa278700e80e",
+                "reference": "4478cc5dd960e2339d88b363ef99fa278700e80e",
                 "shasum": ""
             },
             "require": {
@@ -3869,7 +3868,7 @@
                 "zendframework/zend-router": "^3.0.1",
                 "zendframework/zend-serializer": "^2.6.1",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-session": "^2.8.1",
                 "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
@@ -3893,8 +3892,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9-dev",
-                    "dev-develop": "3.0-dev"
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "2.11.x-dev"
                 }
             },
             "autoload": {
@@ -3912,38 +3911,38 @@
                 "view",
                 "zf2"
             ],
-            "time": "2017-03-21 15:05:56"
+            "time": "2018-01-17T22:21:50+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -3968,7 +3967,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -4038,7 +4037,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2017-03-31 12:59:38"
+            "time": "2017-03-31T12:59:38+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -4080,7 +4079,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "lusitanian/oauth",
@@ -4147,7 +4146,7 @@
                 "oauth",
                 "security"
             ],
-            "time": "2016-07-12 22:15:40"
+            "time": "2016-07-12T22:15:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4192,7 +4191,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19 19:58:43"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -4232,7 +4231,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-01-19 14:23:36"
+            "time": "2017-01-19T14:23:36+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4287,7 +4286,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05 18:14:27"
+            "time": "2017-03-05T18:14:27+00:00"
         },
         {
             "name": "phar-io/version",
@@ -4334,7 +4333,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05 17:38:23"
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4388,7 +4387,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -4439,7 +4438,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27 17:38:31"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4486,7 +4485,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -4552,7 +4551,7 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2017-01-20 14:41:10"
+            "time": "2017-01-20T14:41:10+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -4615,7 +4614,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24 13:59:53"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4678,7 +4677,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06 09:29:45"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4725,7 +4724,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27 13:52:08"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4766,7 +4765,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -4815,7 +4814,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -4864,7 +4863,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27 05:48:46"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -4948,7 +4947,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03 13:59:28"
+            "time": "2017-08-03T13:59:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -5007,7 +5006,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03 14:08:16"
+            "time": "2017-08-03T14:08:16+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5052,7 +5051,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 06:30:41"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5116,7 +5115,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-03-03 06:26:08"
+            "time": "2017-03-03T06:26:08+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5168,7 +5167,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22 07:24:03"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5218,7 +5217,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01 08:51:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5285,7 +5284,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03 13:19:02"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/finder-facade",
@@ -5324,7 +5323,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
-            "time": "2017-11-18 17:31:49"
+            "time": "2017-11-18T17:31:49+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5375,7 +5374,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27 15:39:26"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5422,7 +5421,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03 12:35:26"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -5467,7 +5466,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29 09:07:27"
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/phpcpd",
@@ -5518,7 +5517,7 @@
             ],
             "description": "Copy/Paste Detector (CPD) for PHP code.",
             "homepage": "https://github.com/sebastianbergmann/phpcpd",
-            "time": "2016-04-17 19:32:49"
+            "time": "2016-04-17T19:32:49+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -5571,7 +5570,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03 06:23:57"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -5613,7 +5612,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5656,7 +5655,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5707,20 +5706,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-06-14 01:23:49"
+            "time": "2017-06-14T01:23:49+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.2",
+            "version": "v3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "e57211b88aa889fefac1cb36866db04100b0f21c"
+                "reference": "cfd5c972f7b4992a5df41673d25d980ab077aa5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/e57211b88aa889fefac1cb36866db04100b0f21c",
-                "reference": "e57211b88aa889fefac1cb36866db04100b0f21c",
+                "url": "https://api.github.com/repos/symfony/config/zipball/cfd5c972f7b4992a5df41673d25d980ab077aa5b",
+                "reference": "cfd5c972f7b4992a5df41673d25d980ab077aa5b",
                 "shasum": ""
             },
             "require": {
@@ -5769,20 +5768,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.2",
+            "version": "v3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "5f81907ea43bfa971ac2c7fbac593ebe7cd7d333"
+                "reference": "35f957ca171a431710966bec6e2f8636d3b019c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5f81907ea43bfa971ac2c7fbac593ebe7cd7d333",
-                "reference": "5f81907ea43bfa971ac2c7fbac593ebe7cd7d333",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/35f957ca171a431710966bec6e2f8636d3b019c4",
+                "reference": "35f957ca171a431710966bec6e2f8636d3b019c4",
                 "shasum": ""
             },
             "require": {
@@ -5840,7 +5839,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-12-14 19:40:10"
+            "time": "2018-01-04T15:56:45+00:00"
         },
         {
             "name": "symfony/polyfill-php54",
@@ -5898,7 +5897,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-php55",
@@ -5954,7 +5953,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -6013,7 +6012,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -6068,7 +6067,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-xml",
@@ -6116,20 +6115,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11 12:05:26"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.4.2",
+            "version": "v3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "52510fe1aefdc1c5d2076ac6030421d387e689d1"
+                "reference": "c865551df7c17e63fc1f09f763db04387f91ae4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/52510fe1aefdc1c5d2076ac6030421d387e689d1",
-                "reference": "52510fe1aefdc1c5d2076ac6030421d387e689d1",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/c865551df7c17e63fc1f09f763db04387f91ae4d",
+                "reference": "c865551df7c17e63fc1f09f763db04387f91ae4d",
                 "shasum": ""
             },
             "require": {
@@ -6165,7 +6164,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-07 14:28:09"
+            "time": "2018-01-03T07:37:34+00:00"
         },
         {
             "name": "theseer/fdomdocument",
@@ -6205,7 +6204,7 @@
             ],
             "description": "The classes contained within this repository extend the standard DOM to use exceptions at all occasions of errors instead of PHP warnings or notices. They also add various custom methods and shortcuts for convenience and to simplify the usage of DOM.",
             "homepage": "https://github.com/theseer/fDOMDocument",
-            "time": "2017-06-30 11:53:12"
+            "time": "2017-06-30T11:53:12+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -6245,7 +6244,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07 12:08:54"
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -6295,7 +6294,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],
@@ -6325,5 +6324,7 @@
         "ext-zip": "*",
         "lib-libxml": "*"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "php": "~7.2.0"
+    }
 }

--- a/dev/tests/acceptance/composer.json
+++ b/dev/tests/acceptance/composer.json
@@ -26,6 +26,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "vlucas/phpdotenv": "~2.4"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\": "tests/functional/Magento"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/AdminNotification/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/AdminNotification/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-media-storage": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/AdvancedPricingImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/AdvancedPricingImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-import-export": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Analytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Analytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Authorization/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Authorization/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Authorizenet/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Authorizenet/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Backend/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Backend/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backup": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Backup/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Backup/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-cron": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Braintree/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Braintree/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Bundle/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Bundle/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/BundleImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/BundleImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-bundle": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CacheInvalidate/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CacheInvalidate/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-page-cache": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Captcha/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Captcha/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Catalog/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogInventory/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogInventory/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogRule/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogRule/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogRuleConfigurable/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogRuleConfigurable/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-rule": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogSearch/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogSearch/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogUrlRewrite/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogUrlRewrite/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogWidget/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CatalogWidget/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Checkout/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Checkout/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CheckoutAgreements/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CheckoutAgreements/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cms/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cms/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CmsUrlRewrite/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CmsUrlRewrite/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-cms": "100.0.0-dev",
         "magento/magento2-functional-test-module-store": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Config/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-cron": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-import-export": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableProduct/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableProduct/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableProductSales/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ConfigurableProductSales/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-sales": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Contact/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Contact/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-cms": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cookie/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cookie/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-store": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cron/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Cron/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-store": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CurrencySymbol/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CurrencySymbol/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Customer/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Customer/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CustomerAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CustomerAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-customer": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CustomerImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/CustomerImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-customer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Deploy/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Deploy/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-config": "100.0.0-dev",
         "magento/magento2-functional-test-module-require-js": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Developer/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Developer/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-config": "100.0.0-dev",
         "magento/magento2-functional-test-module-store": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Dhl/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Dhl/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Directory/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Directory/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Downloadable/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Downloadable/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/DownloadableImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/DownloadableImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-import-export": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Eav/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Eav/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Email/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Email/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-cms": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/EncryptionKey/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/EncryptionKey/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Fedex/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Fedex/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GiftMessage/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GiftMessage/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleAdwords/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleAdwords/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-sales": "100.0.0-dev",
         "magento/magento2-functional-test-module-store": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-cookie": "100.0.0-dev",
         "magento/magento2-functional-test-module-sales": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleOptimizer/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GoogleOptimizer/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GraphQl/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GraphQl/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-webapi": "100.0.0-dev",
         "magento/magento2-functional-test-module-eav": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GroupedImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GroupedImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-import-export": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GroupedProduct/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/GroupedProduct/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Indexer/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Indexer/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/InstantPurchase/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/InstantPurchase/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-store": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Integration/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Integration/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/LayeredNavigation/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/LayeredNavigation/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Marketplace/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Marketplace/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/MediaStorage/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/MediaStorage/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Msrp/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Msrp/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-downloadable": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Multishipping/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Multishipping/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",
         "magento/magento2-functional-test-module-customer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/NewRelicReporting/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/NewRelicReporting/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Newsletter/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Newsletter/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-cms": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/OfflinePayments/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/OfflinePayments/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",
         "magento/magento2-functional-test-module-payment": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/OfflineShipping/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/OfflineShipping/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/PageCache/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/PageCache/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Payment/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Payment/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Paypal/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Paypal/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Persistent/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Persistent/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",
         "magento/magento2-functional-test-module-cron": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ProductAlert/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ProductAlert/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ProductVideo/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ProductVideo/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Quote/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Quote/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/QuoteAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/QuoteAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-quote": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Reports/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Reports/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/RequireJs/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/RequireJs/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\RequireJs\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Review/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Review/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ReviewAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/ReviewAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-review": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Robots/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Robots/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-store": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Rss/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Rss/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-customer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Rule/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Rule/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Sales/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Sales/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-sales": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesInventory/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesInventory/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesRule/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesRule/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesSequence/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SalesSequence/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\SalesSequence\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleData/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleData/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\SampleData\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleTemplates/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleTemplates/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\SampleTemplates\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleTests/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SampleTests/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\SampleTests\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Search/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Search/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-search": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Security/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Security/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-store": "100.0.0-dev"

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SendFriend/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SendFriend/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-customer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Shipping/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Shipping/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Sitemap/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Sitemap/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Store/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Store/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-config": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Swagger/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Swagger/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\Swagger\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Swatches/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Swatches/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SwatchesLayeredNavigation/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/SwatchesLayeredNavigation/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\SwatchesLayeredNavigation\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Tax/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Tax/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/TaxImportExport/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/TaxImportExport/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-directory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Theme/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Theme/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-cms": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Translation/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Translation/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-developer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Ui/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Ui/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Ups/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Ups/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/UrlRewrite/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/UrlRewrite/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/User/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/User/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Usps/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Usps/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog-inventory": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Variable/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Variable/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-email": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Vault/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Vault/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-checkout": "100.0.0-dev",
         "magento/magento2-functional-test-module-customer": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Version/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Version/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "autoload": {
         "psr-4": {
             "Magento\\FunctionalTest\\Version\\": ""

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Webapi/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Webapi/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-authorization": "100.0.0-dev",
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/WebapiSecurity/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/WebapiSecurity/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-webapi": "100.0.0-dev"
     },

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Weee/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Weee/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Widget/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Widget/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Wishlist/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/Wishlist/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-backend": "100.0.0-dev",
         "magento/magento2-functional-test-module-catalog": "100.0.0-dev",

--- a/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/WishlistAnalytics/composer.json
+++ b/dev/tests/acceptance/tests/functional/Magento/FunctionalTest/WishlistAnalytics/composer.json
@@ -14,6 +14,9 @@
         "magento/magento2-functional-testing-framework": "1.0.0",
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "magento/magento2-functional-test-module-wishlist": "100.0.0-dev"
     },

--- a/dev/tests/api-functional/_files/Magento/TestModuleIntegrationFromConfig/composer.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleIntegrationFromConfig/composer.json
@@ -9,6 +9,9 @@
     "magento/framework": "0.42.0-beta8",
     "magento/module-integration": "0.42.0-beta8"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "type": "magento2-module",
   "version": "1.0",
   "extra": {

--- a/dev/tests/api-functional/_files/Magento/TestModuleJoinDirectives/composer.json
+++ b/dev/tests/api-functional/_files/Magento/TestModuleJoinDirectives/composer.json
@@ -9,6 +9,9 @@
     "magento/framework": "0.42.0-beta8",
     "magento/module-sales": "0.42.0-beta8"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "type": "magento2-module",
   "version": "1.0",
   "extra": {

--- a/dev/tests/functional/composer.json
+++ b/dev/tests/functional/composer.json
@@ -9,6 +9,9 @@
         "phpunit/phpunit": "~4.8.0|~5.5.0",
         "phpunit/phpunit-selenium": ">=1.2"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "suggest": {
         "netwing/selenium-server-standalone": "dev-master",
         "facebook/webdriver": "dev-master"

--- a/dev/tests/integration/_files/Magento/TestModuleSample/composer.json
+++ b/dev/tests/integration/_files/Magento/TestModuleSample/composer.json
@@ -9,6 +9,9 @@
     "magento/framework": "100.1.*",
     "magento/module-integration": "100.1.*"
   },
+  "require-dev": {
+    "php": "~7.2.0"
+  },
   "type": "magento2-module",
   "version": "1.0",
   "extra": {

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/composer.json
@@ -8,6 +8,9 @@
         "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
         "magento/framework": "1.0.0-beta"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "1.0.0-beta",
     "license": [

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom2/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom2/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "1.0.0-beta",
         "magento/theme-frontend-zoom1": "1.0.0-beta"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "1.0.0-beta",
     "license": [

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom3/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom3/composer.json
@@ -9,6 +9,9 @@
         "magento/framework": "1.0.0-beta",
         "magento/theme-frontend-zoom2": "1.0.0-beta"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "1.0.0-beta",
     "license": [

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/composer.json
@@ -51,6 +51,7 @@
         "zendframework/zend-view": "2.4.0"
     },
     "require-dev": {
+        "php": "~7.2.0",
         "fabpot/php-cs-fixer": "~1.2",
         "lusitanian/oauth": "~0.3",
         "pdepend/pdepend": "2.0.6",

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/A/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/A/composer.json
@@ -8,5 +8,8 @@
         "magento/framework": "0.1",
         "magento/module-b": "0.1"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "version": "0.1"
 }

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/B/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/B/composer.json
@@ -8,5 +8,8 @@
         "magento/framework": "0.74.0-beta6",
         "magento/module-a": "0.1"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "version": "0.1"
 }

--- a/dev/tests/integration/testsuite/Magento/Widget/_files/design/adminhtml/magento_basic/composer.json
+++ b/dev/tests/integration/testsuite/Magento/Widget/_files/design/adminhtml/magento_basic/composer.json
@@ -8,6 +8,9 @@
         "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
         "magento/framework": "0.1.0-alpha103"
     },
+    "require-dev": {
+        "php": "~7.2.0"
+    },
     "type": "magento2-theme",
     "version": "0.1.0"
 }


### PR DESCRIPTION
### Description
Add PHP 7.2 to `require-dev` of all `composer.json` files. Installation with composer will still fail due to third-party extension requirements and the `ext-mcrypt` requirement. 

### Fixed Issues (if relevant)
Fixes #15

### Manual testing scenarios
1. Checkout branch or clone repository
2. Run `composer install`
3. Installation should fail, but not due to Magento's PHP version constraints.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
