### PR TITLE
Removed `create_function()` function usage

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_methods.php
@@ -2528,4 +2528,5 @@ return [
     ['_isAttributeValueEmpty', 'Magento\Catalog\Model\ResourceModel\AbstractResource'],
     ['var_dump', ''],
     ['each', ''],
+    ['create_function', ''],
 ];

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/Constraint/Option/CallbackTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/Constraint/Option/CallbackTest.php
@@ -3,12 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Framework\Validator\Test\Unit\Constraint\Option;
 
-/**
- * Test case for \Magento\Framework\Validator\Constraint\Option\Callback
- */
+use Magento\Framework\Validator\Constraint\Option\Callback;
+use Magento\Framework\Validator\Test\Unit\Test\Callback as TestCallback;
+
 class CallbackTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -28,8 +27,8 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetValue($callback, $expectedResult, $arguments = null, $createInstance = false)
     {
-        $option = new \Magento\Framework\Validator\Constraint\Option\Callback($callback, $arguments, $createInstance);
-        $this->assertEquals($expectedResult, $option->getValue());
+        $option = new Callback($callback, $arguments, $createInstance);
+        self::assertEquals($expectedResult, $option->getValue());
     }
 
     /**
@@ -37,32 +36,37 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
      */
     public function getConfigDataProvider()
     {
-        $functionName = create_function('', 'return "Value from function";');
         $closure = function () {
             return 'Value from closure';
         };
 
-        $mock = $this->getMockBuilder('Foo')->setMethods(['getValue'])->getMock();
-        $mock->expects(
-            $this->once()
-        )->method(
-            'getValue'
-        )->with(
-            'arg1',
-            'arg2'
-        )->will(
-            $this->returnValue('Value from mock')
-        );
+        $mock = $this->getMockBuilder('Foo')
+            ->setMethods(['getValue'])
+            ->getMock();
+        $mock->method('getValue')
+            ->with('arg1', 'arg2')
+            ->willReturn('Value from mock');
 
         return [
-            [$functionName, 'Value from function'],
-            [$closure, 'Value from closure'],
-            [[$this, 'getTestValue'], self::TEST_VALUE],
-            [[__CLASS__, 'getTestValueStatically'], self::TEST_VALUE],
-            [[$mock, 'getValue'], 'Value from mock', ['arg1', 'arg2']],
             [
-                [\Magento\Framework\Validator\Test\Unit\Test\Callback::class, 'getId'],
-                \Magento\Framework\Validator\Test\Unit\Test\Callback::ID,
+                $closure,
+                'Value from closure'
+            ],
+            [
+                [$this, 'getTestValue'],
+                self::TEST_VALUE
+            ],
+            [
+                [__CLASS__, 'getTestValueStatically'],
+                self::TEST_VALUE
+            ],
+            [
+                [$mock, 'getValue'],
+                'Value from mock', ['arg1', 'arg2']
+            ],
+            [
+                [TestCallback::class, 'getId'],
+                TestCallback::ID,
                 null,
                 true
             ]
@@ -90,17 +94,15 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider setArgumentsDataProvider
      *
-     * @param mixed $value
-     * @param mixed $expectedValue
+     * @param string|array $value
+     * @param string|array $expectedValue
      */
     public function testSetArguments($value, $expectedValue)
     {
-        $option = new \Magento\Framework\Validator\Constraint\Option\Callback(
-            function () {
-            }
-        );
+        $option = new Callback(function () {
+        });
         $option->setArguments($value);
-        $this->assertAttributeEquals($expectedValue, '_arguments', $option);
+        self::assertAttributeEquals($expectedValue, '_arguments', $option);
     }
 
     /**
@@ -108,7 +110,13 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
      */
     public function setArgumentsDataProvider()
     {
-        return [['baz', ['baz']], [['foo', 'bar'], ['foo', 'bar']]];
+        return [
+            ['baz', ['baz']],
+            [
+                ['foo', 'bar'],
+                ['foo', 'bar']
+            ]
+        ];
     }
 
     /**
@@ -119,11 +127,12 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
      * @param mixed $callback
      * @param string $expectedMessage
      * @param bool $createInstance
+     * @expectedException \InvalidArgumentException
      */
     public function testGetValueException($callback, $expectedMessage, $createInstance = false)
     {
-        $option = new \Magento\Framework\Validator\Constraint\Option\Callback($callback, null, $createInstance);
-        $this->expectException('InvalidArgumentException', $expectedMessage);
+        $option = new Callback($callback, null, $createInstance);
+        self::expectExceptionMessage($expectedMessage);
         $option->getValue();
     }
 
@@ -139,10 +148,22 @@ class CallbackTest extends \PHPUnit\Framework\TestCase
                 ['Not_Existing_Callback_Class', 'someMethod'],
                 'Class "Not_Existing_Callback_Class" was not found',
             ],
-            [[$this, 'notExistingMethod'], 'Callback does not callable'],
-            [['object' => $this, 'method' => 'getTestValue'], 'Callback does not callable'],
-            ['unknown_function', 'Callback does not callable'],
-            [new \stdClass(), 'Callback does not callable'],
+            [
+                [$this, 'notExistingMethod'],
+                'Callback does not callable'
+            ],
+            [
+                ['object' => $this, 'method' => 'getTestValue'],
+                'Callback does not callable'
+            ],
+            [
+                'unknown_function',
+                'Callback does not callable'
+            ],
+            [
+                new \stdClass(),
+                'Callback does not callable'
+            ],
             [
                 [$this, 'getTestValue'],
                 'Callable expected to be an array with class name as first element',


### PR DESCRIPTION
Removed `create_function()` function usage

### Fixed Issues
1. magento-engcom/php-7.2-support#8: Deprecated: Function create_function() is deprecated

Changes for EE in the internal branch https://github.com/magento-mpi/magento2ee/tree/G%238


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
