### PR TITLE
Made `getAllOptions()` and `toOptionArray()` compatible

### DIFF
--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Group.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Group.php
@@ -42,9 +42,9 @@ class Group extends \Magento\Eav\Model\Entity\Attribute\Source\Table implements 
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $groups = $this->_groupManagement->getLoggedInGroups();

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Store.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Store.php
@@ -40,9 +40,9 @@ class Store extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $collection = $this->_createStoresCollection();

--- a/app/code/Magento/Customer/Model/Customer/Attribute/Source/Website.php
+++ b/app/code/Magento/Customer/Model/Customer/Attribute/Source/Website.php
@@ -32,9 +32,9 @@ class Website extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     }
 
     /**
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = $this->_store->getWebsiteValuesForForm();

--- a/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Country.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Country.php
@@ -45,11 +45,9 @@ class Country extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     }
 
     /**
-     * Retrieve all options
-     *
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = $this->_createCountriesCollection()->loadByStore(

--- a/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/CountryWithWebsites.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/CountryWithWebsites.php
@@ -67,11 +67,9 @@ class CountryWithWebsites extends \Magento\Eav\Model\Entity\Attribute\Source\Tab
     }
 
     /**
-     * Retrieve all options
-     *
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->options) {
             $allowedCountries = [];

--- a/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Region.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/Region.php
@@ -33,11 +33,9 @@ class Region extends \Magento\Eav\Model\Entity\Attribute\Source\Table
     }
 
     /**
-     * Retrieve all region options
-     *
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if (!$this->_options) {
             $this->_options = $this->_createRegionsCollection()->load()->toOptionArray();

--- a/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
+++ b/app/code/Magento/Directory/Model/Config/Source/Country/Full.php
@@ -16,11 +16,10 @@ namespace Magento\Directory\Model\Config\Source\Country;
 class Full extends \Magento\Directory\Model\Config\Source\Country implements \Magento\Framework\Option\ArrayInterface
 {
     /**
-     * @param bool $isMultiselect
-     * @return array
+     * @inheritdoc
      */
-    public function toOptionArray($isMultiselect = false)
+    public function toOptionArray($isMultiselect = false, $foregroundCountries = '')
     {
-        return parent::toOptionArray(true);
+        return parent::toOptionArray(true, $foregroundCountries);
     }
 }

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Store.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Store.php
@@ -35,10 +35,9 @@ class Store extends \Magento\Eav\Model\Entity\Attribute\Source\Table
 
     /**
      * Retrieve Full Option values array
-     *
-     * @return array
+     * @inheritdoc
      */
-    public function getAllOptions()
+    public function getAllOptions($withEmpty = true, $defaultValues = false)
     {
         if ($this->_options === null) {
             $this->_options = $this->_storeCollectionFactory->create()->load()->toOptionArray();

--- a/app/code/Magento/Tax/Model/System/Config/Source/Tax/Country.php
+++ b/app/code/Magento/Tax/Model/System/Config/Source/Tax/Country.php
@@ -13,12 +13,11 @@ class Country extends \Magento\Directory\Model\Config\Source\Country
     protected $_options;
 
     /**
-     * @param bool $noEmpty
-     * @return array
+     * @inheritdoc
      */
-    public function toOptionArray($noEmpty = false)
+    public function toOptionArray($noEmpty = false, $foregroundCountries = '')
     {
-        $options = parent::toOptionArray($noEmpty);
+        $options = parent::toOptionArray($noEmpty, $foregroundCountries);
 
         if (!$noEmpty) {
             if ($options) {

--- a/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
@@ -5,61 +5,63 @@
  */
 namespace Magento\Tax\Test\Unit\Plugin\Checkout\CustomerData;
 
-class CartTest extends \PHPUnit\Framework\TestCase
+use Magento\Checkout\CustomerData\Cart as CheckoutCart;
+use Magento\Checkout\Helper\Data;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Magento\Tax\Block\Item\Price\Renderer;
+use Magento\Tax\Plugin\Checkout\CustomerData\Cart;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class CartTest extends TestCase
 {
+    /**
+     * @var Session|MockObject
+     */
+    private $checkoutSession;
 
     /**
-     * @var \Magento\Checkout\Model\Session
+     * @var Data|MockObject
      */
-    protected $checkoutSession;
+    private $checkoutHelper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Renderer|MockObject
      */
-    protected $checkoutHelper;
+    private $itemPriceRenderer;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var CheckoutCart|MockObject
      */
-    protected $itemPriceRenderer;
+    private $checkoutCart;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Quote|MockObject
      */
-    protected $checkoutCart;
+    private $quote;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Cart
      */
-    protected $quote;
-
-    /**
-     * @var \Magento\Tax\Plugin\Checkout\CustomerData\Cart
-     */
-    protected $cart;
+    private $cart;
 
     protected function setUp()
     {
-        $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $this->checkoutSession = $this->createMock(\Magento\Checkout\Model\Session::class);
-        $this->checkoutHelper = $this->createMock(\Magento\Checkout\Helper\Data::class);
-        $this->itemPriceRenderer = $this->createMock(\Magento\Tax\Block\Item\Price\Renderer::class);
-        $this->checkoutCart = $this->createMock(\Magento\Checkout\CustomerData\Cart::class);
-        $this->quote = $this->createMock(\Magento\Quote\Model\Quote::class);
+        $this->checkoutSession = $this->createMock(Session::class);
+        $this->checkoutHelper = $this->createMock(Data::class);
+        $this->itemPriceRenderer = $this->createMock(Renderer::class);
+        $this->checkoutCart = $this->createMock(CheckoutCart::class);
+        $this->quote = $this->createMock(Quote::class);
 
-        $this->checkoutSession->expects(
-            $this->any()
-        )->method(
-            'getQuote'
-        )->willReturn($this->quote);
-
-        $this->cart = $helper->getObject(
-            \Magento\Tax\Plugin\Checkout\CustomerData\Cart::class,
-            [
-                'checkoutSession' => $this->checkoutSession,
-                'checkoutHelper' => $this->checkoutHelper,
-                'itemPriceRenderer' => $this->itemPriceRenderer,
-            ]
+        $this->checkoutSession->method('getQuote')
+            ->willReturn($this->quote);
+        
+        $this->cart = new Cart(
+            $this->checkoutSession,
+            $this->checkoutHelper,
+            $this->itemPriceRenderer
         );
     }
 
@@ -77,49 +79,34 @@ class CartTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->checkoutHelper->expects(
-            $this->atLeastOnce()
-        )->method(
-            'formatPrice'
-        )->willReturn('formatted');
+        $this->checkoutHelper->method('formatPrice')
+            ->willReturn('formatted');
 
-        $item1 = $this->createMock(\Magento\Quote\Model\Quote\Item::class);
-        $item2 = $this->createMock(\Magento\Quote\Model\Quote\Item::class);
+        $item1 = $this->createMock(Item::class);
+        $item2 = $this->createMock(Item::class);
 
-        $item1->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getItemId'
-        )->willReturn(1);
-        $item2->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getItemId'
-        )->willReturn(2);
+        $item1->method('getItemId')
+            ->willReturn(1);
+        $item2->method('getItemId')
+            ->willReturn(2);
 
-        $this->quote->expects(
-            $this->any()
-        )->method(
-            'getAllVisibleItems'
-        )->willReturn([
-            $item1,
-            $item2,
-        ]);
+        $this->quote->method('getAllVisibleItems')
+            ->willReturn([
+                $item1,
+                $item2,
+            ]);
 
-        $this->itemPriceRenderer->expects(
-            $this->atLeastOnce(1)
-        )->method(
-            'toHtml'
-        )->willReturn(1);
+        $this->itemPriceRenderer->method('toHtml')
+            ->willReturn(1);
 
         $result = $this->cart->afterGetSectionData($this->checkoutCart, $input);
 
-        $this->assertArrayHasKey('subtotal_incl_tax', $result);
-        $this->assertArrayHasKey('subtotal_excl_tax', $result);
-        $this->assertArrayHasKey('items', $result);
-        $this->assertTrue(is_array($result['items']));
-        $this->assertEquals(2, count($result['items']));
-        $this->assertEquals(1, count($result['items'][0]['product_price']));
-        $this->assertEquals(1, count($result['items'][1]['product_price']));
+        self::assertArrayHasKey('subtotal_incl_tax', $result);
+        self::assertArrayHasKey('subtotal_excl_tax', $result);
+        self::assertArrayHasKey('items', $result);
+        self::assertTrue(is_array($result['items']));
+        self::assertEquals(2, count($result['items']));
+        self::assertEquals(1, $result['items'][0]['product_price']);
+        self::assertEquals(1, $result['items'][1]['product_price']);
     }
 }


### PR DESCRIPTION
### Fixed Issues
1. magento-engcom/php-7.2-support#6: \Magento\Framework\Data\OptionSourceInterface::toOptionArray() implementations are incompatible with the interface

Changes for EE in the internal branch https://github.com/magento-mpi/magento2ee/tree/G%236

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
