### PR TITLE
Update colinmollenhour/php-redis-session-abstract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "colinmollenhour/cache-backend-file": "1.4",
         "colinmollenhour/cache-backend-redis": "1.10.2",
         "colinmollenhour/credis": "1.6",
-        "colinmollenhour/php-redis-session-abstract": "~1.2.2",
+        "colinmollenhour/php-redis-session-abstract": "~1.3.8",
         "composer/composer": "1.4.1",
         "magento/composer": "~1.2.0",
         "magento/magento-composer-installer": ">=0.1.11",
@@ -50,6 +50,7 @@
         "symfony/process": "~2.1",
         "tedivm/jshrink": "~1.1.0",
         "tubalmartin/cssmin": "4.1.0",
+        "webonyx/graphql-php": "^0.11.1",
         "zendframework/zend-captcha": "^2.7.1",
         "zendframework/zend-code": "^3.1.0",
         "zendframework/zend-config": "^2.6.0",
@@ -75,8 +76,7 @@
         "zendframework/zend-text": "^2.6.0",
         "zendframework/zend-uri": "^2.5.1",
         "zendframework/zend-validator": "^2.6.0",
-        "zendframework/zend-view": "^2.8.1",
-        "webonyx/graphql-php": "^0.11.1"
+        "zendframework/zend-view": "^2.8.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9114dbda66ca0958916c9e26caf374ce",
+    "content-hash": "ac917da16d41e81ebec458c89210a473",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -166,21 +166,21 @@
         },
         {
             "name": "colinmollenhour/php-redis-session-abstract",
-            "version": "v1.2.2",
+            "version": "v1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/php-redis-session-abstract.git",
-                "reference": "46968f06eeed7d16e8476d8a1397e224047ac6ff"
+                "reference": "9f69f5c1be512d5ff168e731e7fa29ab2905d847"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/php-redis-session-abstract/zipball/46968f06eeed7d16e8476d8a1397e224047ac6ff",
-                "reference": "46968f06eeed7d16e8476d8a1397e224047ac6ff",
+                "url": "https://api.github.com/repos/colinmollenhour/php-redis-session-abstract/zipball/9f69f5c1be512d5ff168e731e7fa29ab2905d847",
+                "reference": "9f69f5c1be512d5ff168e731e7fa29ab2905d847",
                 "shasum": ""
             },
             "require": {
-                "colinmollenhour/credis": "1.6",
-                "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0"
+                "colinmollenhour/credis": "~1.6",
+                "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -199,7 +199,7 @@
             ],
             "description": "A Redis-based session handler with optimistic locking",
             "homepage": "https://github.com/colinmollenhour/php-redis-session-abstract",
-            "time": "2017-04-19T14:21:43+00:00"
+            "time": "2018-01-08T14:53:13+00:00"
         },
         {
             "name": "composer/ca-bundle",

--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
@@ -101,6 +101,26 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     const PARAM_BREAK_AFTER             = 'session/redis/break_after';
 
     /**
+     * Configuration path for comma separated list of sentinel servers
+     */
+    const PARAM_SENTINEL_SERVERS        = 'session/redis/sentinel_servers';
+
+    /**
+     * Configuration path for sentinel master
+     */
+    const PARAM_SENTINEL_MASTER         = 'session/redis/sentinel_master';
+
+    /**
+     * Configuration path for verify sentinel master flag
+     */
+    const PARAM_SENTINEL_VERIFY_MASTER  = 'session/redis/sentinel_verify_master';
+
+    /**
+     * Configuration path for number of sentinel connection retries
+     */
+    const PARAM_SENTINEL_CONNECT_RETRIES = 'session/redis/sentinel_connect_retries';
+
+    /**
      * Cookie lifetime config path
      */
     const XML_PATH_COOKIE_LIFETIME = 'web/cookie/cookie_lifetime';
@@ -114,6 +134,11 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
      * Session max lifetime
      */
     const SESSION_MAX_LIFETIME = 31536000;
+
+    /**
+     * Try to break lock for at most this many seconds
+     */
+    const DEFAULT_FAIL_AFTER = 15;
 
     /**
      * Deployment config
@@ -292,5 +317,45 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
             return (int)$this->scopeConfig->getValue(self::XML_PATH_ADMIN_SESSION_LIFETIME);
         }
         return (int)$this->scopeConfig->getValue(self::XML_PATH_COOKIE_LIFETIME, StoreScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSentinelServers()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_SERVERS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSentinelMaster()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_MASTER);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSentinelVerifyMaster()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_VERIFY_MASTER);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSentinelConnectRetries()
+    {
+        return $this->deploymentConfig->get(self::PARAM_SENTINEL_CONNECT_RETRIES);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFailAfter()
+    {
+        return self::DEFAULT_FAIL_AFTER;
     }
 }

--- a/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandler/Redis/ConfigTest.php
@@ -246,4 +246,49 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->willReturn($expectedLifetime);
         $this->assertEquals($this->config->getLifetime(), $expectedLifetime);
     }
+
+    public function testGetSentinelServers()
+    {
+        $expected = 'server-1,server-2';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_SERVERS)
+            ->willReturn($expected);
+        $this->assertEquals($expected, $this->config->getSentinelServers());
+    }
+
+    public function testGetSentinelMaster()
+    {
+        $expected = 'master';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_MASTER)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelMaster(), $expected);
+    }
+
+    public function testGetSentinelVerifyMaster()
+    {
+        $expected = '1';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->with(Config::PARAM_SENTINEL_VERIFY_MASTER)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelVerifyMaster(), $expected);
+    }
+
+    public function testGetSentinelConnectRetries()
+    {
+        $expected = '10';
+        $this->deploymentConfigMock->expects($this->once())
+            ->method('get')
+            ->willReturn(Config::PARAM_SENTINEL_CONNECT_RETRIES)
+            ->willReturn($expected);
+        $this->assertEquals($this->config->getSentinelConnectRetries(), $expected);
+    }
+
+    public function testGetFailAfter()
+    {
+        $this->assertEquals($this->config->getFailAfter(), Config::DEFAULT_FAIL_AFTER);
+    }
 }

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
@@ -37,6 +37,10 @@ class Session implements ConfigOptionsListInterface
     const INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING = 'session-save-redis-disable-locking';
     const INPUT_KEY_SESSION_REDIS_MIN_LIFETIME = 'session-save-redis-min-lifetime';
     const INPUT_KEY_SESSION_REDIS_MAX_LIFETIME = 'session-save-redis-max-lifetime';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_SERVERS = 'session-save-redis-sentinel-servers';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER = 'session-save-redis-sentinel-master';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_VERIFY_MASTER = 'session-save-redis-sentinel-verify-master';
+    const INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES = 'session-save-redis-sentinel-connect-retires';
 
     const CONFIG_PATH_SESSION_REDIS = 'session/redis';
     const CONFIG_PATH_SESSION_REDIS_HOST = 'session/redis/host';
@@ -57,6 +61,10 @@ class Session implements ConfigOptionsListInterface
     const CONFIG_PATH_SESSION_REDIS_DISABLE_LOCKING = 'session/redis/disable_locking';
     const CONFIG_PATH_SESSION_REDIS_MIN_LIFETIME = 'session/redis/min_lifetime';
     const CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME = 'session/redis/max_lifetime';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_SERVERS = 'session/redis/sentinel_servers';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER = 'session/redis/sentinel_master';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_VERIFY_MASTER = 'session/redis/sentinel_verify_master';
+    const CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES = 'session/redis/sentinel_connect_retries';
 
     /**
      * @var array
@@ -80,7 +88,9 @@ class Session implements ConfigOptionsListInterface
         self::INPUT_KEY_SESSION_REDIS_BOT_LIFETIME => '7200',
         self::INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING => '0',
         self::INPUT_KEY_SESSION_REDIS_MIN_LIFETIME => '60',
-        self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => '2592000'
+        self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => '2592000',
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_VERIFY_MASTER => '0',
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES => '5',
     ];
 
     /**
@@ -121,6 +131,11 @@ class Session implements ConfigOptionsListInterface
         self::INPUT_KEY_SESSION_REDIS_DISABLE_LOCKING => self::CONFIG_PATH_SESSION_REDIS_DISABLE_LOCKING,
         self::INPUT_KEY_SESSION_REDIS_MIN_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_MIN_LIFETIME,
         self::INPUT_KEY_SESSION_REDIS_MAX_LIFETIME => self::CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_SERVERS => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_SERVERS,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES =>
+            self::CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
+        self::INPUT_KEY_SESSION_REDIS_SENTINEL_VERIFY_MASTER => self::CONFIG_PATH_SESSION_REDIS_SENTINEL_VERIFY_MASTER,
     ];
 
     /**
@@ -245,6 +260,30 @@ class Session implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_SESSION_REDIS_MAX_LIFETIME,
                 'Redis max session lifetime, in seconds'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_MASTER,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_MASTER,
+                'Redis Sentinel master'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_SERVERS,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_SERVERS,
+                'Redis Sentinel servers, comma separated'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_VERIFY_MASTER,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_VERIFY_MASTER,
+                'Redis Sentinel verify master. Values: false (default), true'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_SESSION_REDIS_SENTINEL_CONNECT_RETRIES,
+                'Redis Sentinel connect retries.'
             ),
         ];
     }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/SessionTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/SessionTest.php
@@ -32,7 +32,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configList->getOptions();
-        $this->assertCount(19, $options);
+        $this->assertCount(23, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -156,7 +156,11 @@ class SessionTest extends \PHPUnit\Framework\TestCase
                     'bot_lifetime' => '',
                     'disable_locking' => '',
                     'min_lifetime' => '',
-                    'max_lifetime' => ''
+                    'max_lifetime' => '',
+                    'sentinel_master' => '',
+                    'sentinel_servers' => '',
+                    'sentinel_connect_retries' => '',
+                    'sentinel_verify_master' => '',
                 ]
 
             ]
@@ -209,7 +213,11 @@ class SessionTest extends \PHPUnit\Framework\TestCase
                     'bot_lifetime' => '',
                     'disable_locking' => '',
                     'min_lifetime' => '60',
-                    'max_lifetime' => '3600'
+                    'max_lifetime' => '3600',
+                    'sentinel_master' => '',
+                    'sentinel_servers' => '',
+                    'sentinel_connect_retries' => '',
+                    'sentinel_verify_master' => '',
                 ]
             ],
 


### PR DESCRIPTION
### Description
Update colinmollenhour/php-redis-session-abstract to version supporting PHP 7.2.

### Fixed Issues (if relevant)
1. magento-engcom/php-7.2-support#1

### Manual testing scenarios
1. Install Magento
2. Configure caches to use Redis

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
