### PR TITLE
Replace ZF1 Zend_Feed with ZF2/3 Zend\Feed

### DIFF
--- a/app/code/Magento/Rss/Model/Rss.php
+++ b/app/code/Magento/Rss/Model/Rss.php
@@ -8,6 +8,7 @@ namespace Magento\Rss\Model;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\Rss\DataProviderInterface;
 use Magento\Framework\Serialize\SerializerInterface;
+use Zend\Feed\Writer\FeedFactory;
 
 /**
  * Provides functionality to work with RSS feeds
@@ -92,7 +93,7 @@ class Rss
      */
     public function createRssXml()
     {
-        $rssFeedFromArray = \Zend_Feed::importArray($this->getFeeds(), 'rss');
-        return $rssFeedFromArray->saveXML();
+        $feed = FeedFactory::factory($this->getFeeds());
+        return $feed->export('rss');
     }
 }

--- a/app/code/Magento/Rss/Test/Unit/Controller/Adminhtml/Feed/IndexTest.php
+++ b/app/code/Magento/Rss/Test/Unit/Controller/Adminhtml/Feed/IndexTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Rss\Test\Unit\Controller\Adminhtml\Feed;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Zend\Feed\Writer\Exception\InvalidArgumentException;
 
 /**
  * Class IndexTest
@@ -110,7 +111,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         $this->rssFactory->expects($this->once())->method('create')->will($this->returnValue($rssModel));
         $this->rssManager->expects($this->once())->method('getProvider')->will($this->returnValue($dataProvider));
 
-        $this->expectException('\Zend_Feed_Builder_Exception');
+        $this->expectException(InvalidArgumentException::class);
         $this->controller->execute();
     }
 }

--- a/app/code/Magento/Rss/Test/Unit/Controller/Feed/IndexTest.php
+++ b/app/code/Magento/Rss/Test/Unit/Controller/Feed/IndexTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Rss\Test\Unit\Controller\Feed;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Zend\Feed\Writer\Exception\InvalidArgumentException;
 
 /**
  * Class IndexTest
@@ -97,7 +98,7 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         $this->rssFactory->expects($this->once())->method('create')->will($this->returnValue($rssModel));
         $this->rssManager->expects($this->once())->method('getProvider')->will($this->returnValue($dataProvider));
 
-        $this->expectException('\Zend_Feed_Builder_Exception');
+        $this->expectException(InvalidArgumentException::class);
         $this->controller->execute();
     }
 }

--- a/app/code/Magento/Rss/Test/Unit/Model/RssTest.php
+++ b/app/code/Magento/Rss/Test/Unit/Model/RssTest.php
@@ -119,11 +119,11 @@ class RssTest extends \PHPUnit\Framework\TestCase
         $this->rss->setDataProvider($dataProvider);
         $result = $this->rss->createRssXml();
         $this->assertContains('<?xml version="1.0" encoding="UTF-8"?>', $result);
-        $this->assertContains('<title><![CDATA[Feed Title]]></title>', $result);
-        $this->assertContains('<title><![CDATA[Feed 1 Title]]></title>', $result);
+        $this->assertContains('<title>Feed Title</title>', $result);
+        $this->assertContains('<title>Feed 1 Title</title>', $result);
         $this->assertContains('<link>http://magento.com/rss/link</link>', $result);
         $this->assertContains('<link>http://magento.com/rss/link/id/1</link>', $result);
-        $this->assertContains('<description><![CDATA[Feed Description]]></description>', $result);
+        $this->assertContains('<description>Feed Description</description>', $result);
         $this->assertContains('<description><![CDATA[Feed 1 Description]]></description>', $result);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "zendframework/zend-db": "^2.8.2",
         "zendframework/zend-di": "^2.6.1",
         "zendframework/zend-eventmanager": "^2.6.3",
+        "zendframework/zend-feed": "^2.9.0",
         "zendframework/zend-form": "^2.10.0",
         "zendframework/zend-http": "^2.6.0",
         "zendframework/zend-i18n": "^2.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "19f6c01c03032849ec8101511a02d174",
+    "content-hash": "03ece269ddc8227e813e176dad41a986",
     "packages": [
         {
             "name": "braintree/braintree_php",
@@ -2432,6 +2432,67 @@
                 "zf2"
             ],
             "time": "2017-12-12T17:48:56+00:00"
+        },
+        {
+            "name": "zendframework/zend-feed",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-feed.git",
+                "reference": "abe88686124d492e0a2a84656f15e5482bfbe030"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/abe88686124d492e0a2a84656f15e5482bfbe030",
+                "reference": "abe88686124d492e0a2a84656f15e5482bfbe030",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-escaper": "^2.5.2",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "psr/http-message": "^1.0.1",
+                "zendframework/zend-cache": "^2.7.2",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-db": "^2.8.2",
+                "zendframework/zend-http": "^2.7",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
+                "zendframework/zend-validator": "^2.10.1"
+            },
+            "suggest": {
+                "psr/http-message": "PSR-7 ^1.0.1, if you wish to use Zend\\Feed\\Reader\\Http\\Psr7ResponseDecorator",
+                "zendframework/zend-cache": "Zend\\Cache component, for optionally caching feeds between requests",
+                "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
+                "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
+                "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries when using the Writer subcomponent"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev",
+                    "dev-develop": "2.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Feed\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides functionality for consuming RSS and Atom feeds",
+            "keywords": [
+                "ZendFramework",
+                "feed",
+                "zf"
+            ],
+            "time": "2017-12-04T17:59:38+00:00"
         },
         {
             "name": "zendframework/zend-filter",

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
@@ -4220,4 +4220,5 @@ return [
     ['Magento\Framework\MessageQueue\Config\Reader', 'Magento\Framework\MessageQueue\Config\Reader\Xml'],
     ['Magento\Framework\MessageQueue\PublisherFactory'],
     ['Magento\Framework\MessageQueue\PublisherProxy'],
+    ['Zend_Feed', 'Zend\Feed'],
 ];


### PR DESCRIPTION
### Description

Replacing ZF1 Zend_Feed with Zend\Feed allows us to eliminate it as a module from Zend framework, and opens up many other additional modules that were otherwise dependencies on it.

### Fixed Issues (if relevant)

1. magento-engcom/php-7.2-support#70: Eliminate usage of Zend_Feed from Magento 2 Open Source

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
