### PR TITLE
Update zend-soap #37

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "zendframework/zend-server": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.8",
         "zendframework/zend-session": "^2.7.3",
-        "zendframework/zend-soap": "^2.6.0",
+        "zendframework/zend-soap": "^2.7.0",
         "zendframework/zend-stdlib": "^2.7.7",
         "zendframework/zend-text": "^2.6.0",
         "zendframework/zend-uri": "^2.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "03cd971b78790a885bd0a45354a34d90",
+    "content-hash": "f5c0c61d6a0bce888692dd5824e6c53f",
     "packages": [
         {
             "name": "braintree/braintree_php",


### PR DESCRIPTION
### Description
Update zend-soap to the version that supports PHP 7.2 - ver. 2.7.0
composer.lock already has zend-soap in version 2.7.0, this information
was missing in composer.json.

### Fixed Issues (if relevant)
Update zend-soap https://github.com/magento-engcom/php-7.2-support/issues/37 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)