### PR TITLE
Eliminate usage of Zend_Config from Magento 2 Open Source #71

### DIFF
--- a/app/code/Magento/Integration/Model/Oauth/Consumer/Validator/KeyLength.php
+++ b/app/code/Magento/Integration/Model/Oauth/Consumer/Validator/KeyLength.php
@@ -39,7 +39,7 @@ class KeyLength extends \Zend_Validate_StringLength
      * Default encoding is set to utf-8 if none provided
      * New option name added to allow adding key name in validation error messages
      *
-     * @param  integer|array|\Zend_Config $options
+     * @inheritdoc
      */
     public function __construct($options = [])
     {

--- a/lib/internal/Magento/Framework/Validator/EmailAddress.php
+++ b/lib/internal/Magento/Framework/Validator/EmailAddress.php
@@ -7,8 +7,6 @@
  */
 namespace Magento\Framework\Validator;
 
-use Zend_Config;
-
 class EmailAddress extends \Zend_Validate_EmailAddress implements \Magento\Framework\Validator\ValidatorInterface
 {
     /**
@@ -21,7 +19,7 @@ class EmailAddress extends \Zend_Validate_EmailAddress implements \Magento\Frame
      * 'mx'       => If MX check should be enabled, boolean
      * 'deep'     => If a deep MX check should be done, boolean
      *
-     * @param array|string|Zend_Config $options OPTIONAL
+     * @inheritdoc
      */
     public function __construct($options = [])
     {


### PR DESCRIPTION
Remove all references of Zend_Config

Removed all instances/references to Zend_Config within the Magento 2 core. The approach with this is to inherit the docblocks in the files where it still exists.

The complete removal of the project dependency on Zend Framework 1 will require the removal of Zend_Validate which is currently in PR:
https://github.com/magento-engcom/php-7.2-support/issues/82

The changes here aren't reflected in issue 82

### Description
Remove import of Zend_Config in oAuth keylength validator and inherit previously copy/pasted Docblock
Import previously copy/pasted docblock from email address validator

### Fixed Issues (if relevant)
1. magento-engcom/php-7.2-support#71: Eliminate usage of Zend_Config from Magento 2 Open Source #71

### Manual testing scenarios
No functionality changed import of Zend_Config was purely for usage in Docblock

### Contribution checklist
 - [X ] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds on Travis CI are green)
