### PR TITLE
74: Eliminate usage of Zend_Uri from Magento 2 Open Source

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -18,6 +18,7 @@ use Magento\Framework\Model\AbstractExtensibleModel;
 use Magento\Framework\Url\ScopeInterface as UrlScopeInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Api\Data\StoreInterface;
+use Zend\Uri\UriFactory;
 
 /**
  * Store model
@@ -801,7 +802,7 @@ class Store extends AbstractExtensibleModel implements
             return false;
         }
 
-        $uri = \Zend_Uri::factory($secureBaseUrl);
+        $uri = UriFactory::factory($secureBaseUrl);
         $port = $uri->getPort();
         $serverPort = $this->_request->getServer('SERVER_PORT');
         $isSecure = $uri->getScheme() == 'https' && isset($serverPort) && $port == $serverPort;

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
@@ -4234,5 +4234,6 @@ return [
         'Magento\Elasticsearch\Test\Unit\Model\SearchAdapter\ConnectionManagerTest',
         'Magento\Elasticsearch\Test\Unit\SearchAdapter\ConnectionManagerTest'
     ],
-    ['Zend_Feed', 'Zend\Feed']
+    ['Zend_Feed', 'Zend\Feed'],
+    ['Zend_Uri', 'Zend\Uri\Uri']
 ];

--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -154,7 +154,7 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
      * Send request to the remote server
      *
      * @param string $method
-     * @param \Zend_Uri_Http|string $url
+     * @param string $url
      * @param string $http_ver
      * @param array $headers
      * @param string $body
@@ -163,9 +163,6 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
      */
     public function write($method, $url, $http_ver = '1.1', $headers = [], $body = '')
     {
-        if ($url instanceof \Zend_Uri_Http) {
-            $url = $url->getUri();
-        }
         $this->_applyConfig();
 
         // set url to post to

--- a/lib/internal/Magento/Framework/HTTP/ZendClient.php
+++ b/lib/internal/Magento/Framework/HTTP/ZendClient.php
@@ -21,7 +21,7 @@ class ZendClient extends \Zend_Http_Client
     protected $_urlEncodeBody = true;
 
     /**
-     * @param null|\Zend_Uri_Http|string $uri
+     * @param null|string $uri
      * @param null|array $config
      */
     public function __construct($uri = null, $config = null)

--- a/lib/internal/Magento/Framework/Oauth/Helper/Request.php
+++ b/lib/internal/Magento/Framework/Oauth/Helper/Request.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\Oauth\Helper;
 
 use Magento\Framework\App\RequestInterface;
+use Zend\Uri\UriFactory;
 
 class Request
 {
@@ -95,7 +96,7 @@ class Request
         }
         $protocolParamsNotSet = !$protocolParams;
 
-        $queryString = \Zend_Uri_Http::fromString($requestUrl)->getQuery();
+        $queryString = UriFactory::factory($requestUrl)->getQuery();
         $this->_extractQueryStringParams($protocolParams, $queryString);
 
         if ($protocolParamsNotSet) {

--- a/lib/internal/Magento/Framework/Url/Validator.php
+++ b/lib/internal/Magento/Framework/Url/Validator.php
@@ -11,6 +11,8 @@
  */
 namespace Magento\Framework\Url;
 
+use Zend\Uri\UriFactory;
+
 class Validator extends \Zend_Validate_Abstract
 {
     /**#@+
@@ -45,11 +47,14 @@ class Validator extends \Zend_Validate_Abstract
     {
         $this->_setValue($value);
 
-        if (!\Zend_Uri::check($value)) {
-            $this->_error(self::INVALID_URL);
-            return false;
-        }
+        try {
+            $uri = UriFactory::factory($value);
+            if ($uri->isValid()) {
+                return true;
+            }
+        } catch (Exception $e) {/** left empty */}
 
-        return true;
+        $this->_error(self::INVALID_URL);
+        return false;
     }
 }

--- a/lib/internal/Magento/Framework/Webapi/Request.php
+++ b/lib/internal/Magento/Framework/Webapi/Request.php
@@ -34,7 +34,7 @@ class Request extends HttpRequest implements RequestInterface
      * @param StringUtils $converter
      * @param AreaList $areaList
      * @param ScopeInterface $configScope
-     * @param null|string|\Zend_Uri $uri
+     * @param null|string $uri
      */
     public function __construct(
         CookieReaderInterface $cookieReader,


### PR DESCRIPTION
### Description

- Replacing usages of Zend_Uri classes with Zend Uri clases from ZF-3.
- Removed Zend_Uri typehints that were never used, a common pattern I saw was that the Zend_Uri  class was typehinted along with a type string but Magento always passes a string to the method so the Zend_Uri could safely be removed.

Would be good to know how to run static test to make sure 100%.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
