### PR TITLE
Fix Call to undefined function Magento\Ui\Controller\Adminhtml\Index\_()

### DIFF
--- a/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
+++ b/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php
@@ -100,7 +100,7 @@ class Render extends AbstractAction
         } catch (\Exception $e) {
             $this->logger->critical($e);
             $result = [
-                'error' => _('UI component could not be rendered because of system exception'),
+                'error' => __('UI component could not be rendered because of system exception'),
                 'errorcode' => $this->escaper->escapeHtml($e->getCode())
             ];
             /** @var \Magento\Framework\Controller\Result\Json $resultJson */


### PR DESCRIPTION
A call on file [app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php](https://github.com/magento-engcom/php-7.2-support/blob/libs-upgrade/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php#L103) to the translation logic is using one underscore when the function should be called with two.
This breaks test `Magento\Ui\Test\Unit\Controller\Adminhtml\Index\RenderTest::testExecuteAjaxRequestException`

> 1) Magento\Ui\Test\Unit\Controller\Adminhtml\Index\RenderTest::testExecuteAjaxRequestException
> Error: Call to undefined function Magento\Ui\Controller\Adminhtml\Index\_()
> 
> /var/builds/magento2/app/code/Magento/Ui/Controller/Adminhtml/Index/Render.php:103
> /var/builds/magento2/app/code/Magento/Ui/Controller/Adminhtml/AbstractAction.php:62
> /var/builds/magento2/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php:238

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
