### PR TITLE
Eliminate usage of Zend_Mime from Magento 2 Open Source

### DIFF
--- a/app/code/Magento/Downloadable/Controller/Download.php
+++ b/app/code/Magento/Downloadable/Controller/Download.php
@@ -64,7 +64,7 @@ abstract class Download extends \Magento\Framework\App\Action\Action
         $contentDisposition = $helper->getContentDisposition();
         if (!$contentDisposition || in_array($contentType, $this->disallowedContentTypes)) {
             // For security reasons we force browsers to download the file instead of opening it.
-            $contentDisposition = \Zend_Mime::DISPOSITION_ATTACHMENT;
+            $contentDisposition = \Magento\Framework\HTTP\Mime::DISPOSITION_ATTACHMENT;
         }
 
         $response->setHeader('Content-Disposition', $contentDisposition  . '; filename=' . $fileName);

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
@@ -492,8 +492,8 @@ class LinkTest extends \PHPUnit\Framework\TestCase
     public function downloadTypesDataProvider()
     {
         return [
-            ['mimeType' => 'text/html',  'disposition' => \Zend_Mime::DISPOSITION_ATTACHMENT],
-            ['mimeType' => 'image/jpeg', 'disposition' => \Zend_Mime::DISPOSITION_INLINE],
+            ['mimeType' => 'text/html',  'disposition' => \Magento\Framework\HTTP\Mime::DISPOSITION_ATTACHMENT],
+            ['mimeType' => 'image/jpeg', 'disposition' => \Magento\Framework\HTTP\Mime::DISPOSITION_INLINE],
         ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
@@ -169,9 +169,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractController
             \Magento\TestFramework\Mail\Template\TransportBuilderMock::class
         );
 
-        $actualResult = \Zend_Mime_Decode::decodeQuotedPrintable(
-            $transportBuilder->getSentMessage()->getRawMessage()
-        );
+        $actualResult = quoted_printable_decode($transportBuilder->getSentMessage()->getRawMessage());
 
         $this->assertStringMatchesFormat(
             '%A' . $this->_customerViewHelper->getCustomerName($this->_customerSession->getCustomerDataObject())

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
@@ -4234,5 +4234,6 @@ return [
         'Magento\Elasticsearch\Test\Unit\Model\SearchAdapter\ConnectionManagerTest',
         'Magento\Elasticsearch\Test\Unit\SearchAdapter\ConnectionManagerTest'
     ],
-    ['Zend_Feed', 'Zend\Feed']
+    ['Zend_Feed', 'Zend\Feed'],
+    ['Zend_Mime', 'Magento\Framework\HTTP\Mime'],
 ];

--- a/lib/internal/Magento/Framework/HTTP/Mime.php
+++ b/lib/internal/Magento/Framework/HTTP/Mime.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\HTTP;
+
+/**
+ * Support class for MultiPart Mime Messages
+ */
+class Mime
+{
+    const TYPE_OCTETSTREAM         = 'application/octet-stream';
+    const TYPE_TEXT                = 'text/plain';
+    const TYPE_HTML                = 'text/html';
+    const ENCODING_7BIT            = '7bit';
+    const ENCODING_8BIT            = '8bit';
+    const ENCODING_QUOTEDPRINTABLE = 'quoted-printable';
+    const ENCODING_BASE64          = 'base64';
+    const DISPOSITION_ATTACHMENT   = 'attachment';
+    const DISPOSITION_INLINE       = 'inline';
+    const LINELENGTH               = 72;
+    const LINEEND                  = "\n";
+    const MULTIPART_ALTERNATIVE    = 'multipart/alternative';
+    const MULTIPART_MIXED          = 'multipart/mixed';
+    const MULTIPART_RELATED        = 'multipart/related';
+}


### PR DESCRIPTION
### Description

Add Magento's own Mime class to replace usage of Zend_Mime
Zend_Mime package can now be removed.
Also removes call to Zend_Mime_Decode::decodeQuotedPrintable()
Duplicate of magento-engcom/php-7.2-support#102

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
