### PR TITLE
Eliminate usage of Zend_Exception from Magento 2 Open Source

### DIFF
--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Fixture/FieldsProvider.php
@@ -182,14 +182,14 @@ class FieldsProvider
      * Retrieve connection to resource specified by $resourceName.
      *
      * @param string $resourceName
-     * @return \Exception|false|\Magento\Framework\DB\Adapter\AdapterInterface|\Zend_Exception
+     * @return \Exception|false|\Magento\Framework\DB\Adapter\AdapterInterface
      */
     protected function getConnection($resourceName)
     {
         try {
             $connection = $this->resource->getConnection($resourceName);
             return $connection;
-        } catch (\Zend_Exception $e) {
+        } catch (\Exception $e) {
             echo $e->getMessage() . PHP_EOL;
             return $e;
         }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
Remove the last use of Zend_Exception

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento-engcom/php-7.2-support/issues/68: Eliminate usage of Zend_Exception from Magento 2 Open Source

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
Not needed, all covered by Travis: https://travis-ci.org/mhauri/php-7.2-support/builds/364521324

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
