### PR TITLE
Fix braintree_php version to match base composer.json

### DIFF
--- a/app/code/Magento/Braintree/composer.json
+++ b/app/code/Magento/Braintree/composer.json
@@ -6,7 +6,7 @@
     },
     "require": {
         "php": "~7.1.3||~7.2.0",
-        "braintree/braintree_php": "3.22.0",
+        "braintree/braintree_php": "3.28.0",
         "magento/framework": "*",
         "magento/magento-composer-installer": "*",
         "magento/module-catalog": "*",


### PR DESCRIPTION
braintree/braintree_php version in Braintree module does not match version in base composer.json.
