### PR TITLE
Eliminate usage of Zend_Mail from Magento 2 Open Source

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -8,7 +8,7 @@ namespace Magento\Email\Model;
 use Magento\Backend\App\Area\FrontNameResolver as BackendFrontNameResolver;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\App\TemplateTypesInterface;;
+use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\View\DesignInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;

--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -8,7 +8,7 @@ namespace Magento\Email\Model;
 use Magento\Backend\App\Area\FrontNameResolver as BackendFrontNameResolver;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\App\TemplateTypesInterface;
+use Magento\Framework\App\TemplateTypesInterface;;
 use Magento\Framework\View\DesignInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
@@ -25,9 +25,9 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
     protected $model;
 
     /**
-     * @var \Zend_Mail|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Mail\Message|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $mail;
+    protected $message;
 
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -45,8 +45,8 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
             $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);
         }
 
-        $this->mail = $this->getMockBuilder(\Zend_Mail::class)
-            ->setMethods(['send', 'addTo', 'addBcc', 'setReturnPath', 'setReplyTo'])
+        $this->message = $this->getMockBuilder(\Magento\Framework\Mail\Message::class)
+            ->setMethods(['addTo', 'addBcc', 'setReplyTo'])
             ->setConstructorArgs(['utf-8'])
             ->getMock();
 
@@ -71,18 +71,18 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
 
         $this->objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('frontend');
 
-        $this->model->expects($this->any())->method('_getMail')->will($this->returnCallback([$this, 'getMail']));
+        $this->model->expects($this->any())->method('_getMail')->will($this->returnCallback([$this, 'getMessage']));
         $this->model->setSenderName('sender')->setSenderEmail('sender@example.com')->setTemplateSubject('Subject');
     }
 
     /**
-     * Return a disposable \Zend_Mail instance
+     * Return a disposable \Magento\Framework\Mail\Message instance
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Zend_Mail
      */
-    public function getMail()
+    public function getMessage()
     {
-        return clone $this->mail;
+        return clone $this->message;
     }
 
     public function testSetGetTemplateFilter()

--- a/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/TemplateTest.php
@@ -51,7 +51,7 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->model = $this->getMockBuilder(\Magento\Email\Model\Template::class)
-            ->setMethods(['_getMail'])
+            ->setMethods(['mockableMethod'])
             ->setConstructorArgs([
                 $this->objectManager->get(\Magento\Framework\Model\Context::class),
                 $this->objectManager->get(\Magento\Framework\View\DesignInterface::class),
@@ -70,19 +70,7 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('frontend');
-
-        $this->model->expects($this->any())->method('_getMail')->will($this->returnCallback([$this, 'getMessage']));
         $this->model->setSenderName('sender')->setSenderEmail('sender@example.com')->setTemplateSubject('Subject');
-    }
-
-    /**
-     * Return a disposable \Magento\Framework\Mail\Message instance
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Zend_Mail
-     */
-    public function getMessage()
-    {
-        return clone $this->message;
     }
 
     public function testSetGetTemplateFilter()

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/_files/obsolete_classes.php
@@ -4237,4 +4237,5 @@ return [
     ['Zend_Feed', 'Zend\Feed'],
     ['Zend_Uri', 'Zend\Uri\Uri'],
     ['Zend_Mime', 'Magento\Framework\HTTP\Mime'],
+    ['Zend_Mail', 'Zend\Mail'],
 ];


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description

- all references to Zend_Mail are removed from Magento 2 Open Source
- added static a test that verifies that Zend_Mail is not used
- Travis builds are green on PHP 7.1 environment, see: https://travis-ci.org/mhauri/php-7.2-support/builds/386828793
- ~~all backward incompatible changes are documented (if any)~~
- if ZF1 component replaced by ZF2 component:

  - there is an explanation why it is required to use external dependency
See: https://github.com/magento/magento2/pull/8608


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. #72 Eliminate usage of Zend_Mail from Magento 2 Open Source


### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
